### PR TITLE
Added JetBrains Rider's .idea directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ msbuild.log
 # Visual Studio 2015
 .vs/
 
+# JetBrains Rider
+.idea/
+
 # Visual Studio 2015 Pre-CTP6
 *.sln.ide
 *.ide/


### PR DESCRIPTION
This is just the working directory of JetBrain's Rider IDE, similar to .vs in later versions of video studio.