### PR TITLE
Fix usage of boolean uniform variables, with test

### DIFF
--- a/src/ShaderGen.Tests/ShaderGeneratorTests.cs
+++ b/src/ShaderGen.Tests/ShaderGeneratorTests.cs
@@ -42,6 +42,7 @@ namespace ShaderGen.Tests
             yield return new object[] { "TestShaders.UIntVectors.VS", null };
             yield return new object[] { "TestShaders.VeldridShaders.UIntVertexAttribs.VS", null };
             yield return new object[] { "TestShaders.SwitchStatements.VS", null };
+            yield return new object[] { "TestShaders.VariableTypes.VS", null };
         }
 
         public static IEnumerable<object[]> ComputeShaders()

--- a/src/ShaderGen.Tests/TestAssets/VariableTypes.cs
+++ b/src/ShaderGen.Tests/TestAssets/VariableTypes.cs
@@ -1,0 +1,31 @@
+﻿using ShaderGen;
+using System.Numerics;
+
+namespace TestShaders
+{
+    public class VariableTypes
+    {
+        public bool SkinningEnabled;
+
+        [VertexShader]
+        public VertexOutput VS(PositionTexture input)
+        {
+            VertexOutput output;
+            if (SkinningEnabled)
+            {
+                output.Position = new Vector4(1, 1, 1, 1);
+            }
+            else
+            {
+                output.Position = new Vector4(0, 1, 1, 1);
+            }
+            return output;
+        }
+
+        public struct VertexOutput
+        {
+            [VertexSemantic(SemanticType.SystemPosition)]
+            public Vector4 Position;
+        }
+    }
+}

--- a/src/ShaderGen/ShaderPrimitiveTypes.cs
+++ b/src/ShaderGen/ShaderPrimitiveTypes.cs
@@ -9,6 +9,7 @@ namespace ShaderGen
             "float",
             "System.Single",
             "int",
+            "System.Boolean",
             "System.UInt32",
             "System.Int32",
             "System.Numerics.Vector2",


### PR DESCRIPTION
Without this fix, usage of boolean uniform variables throws an exception because of the missing boolean type in `s_primitiveTypes`.