### PR TITLE
Fixed build warnings

### DIFF
--- a/src/ShaderGen.Tests/ShaderGeneratorTests.cs
+++ b/src/ShaderGen.Tests/ShaderGeneratorTests.cs
@@ -271,46 +271,5 @@ namespace ShaderGen.Tests
 
             Assert.Throws<ShaderGenerationException>(() => sg.GenerateShaders());
         }
-
-        [Fact]
-        public void DummyTest()
-        {
-            string vsName = "TestShaders.VertexAndFragment.VS";
-            string fsName = "TestShaders.VertexAndFragment.FS";
-            Compilation compilation = TestUtil.GetTestProjectCompilation();
-            using (TempFile fp = new TempFile())
-            {
-                Microsoft.CodeAnalysis.Emit.EmitResult emitResult = compilation.Emit(fp);
-                Assert.True(emitResult.Success);
-            }
-
-            LanguageBackend backend = new Glsl450Backend(compilation);
-            ShaderGenerator sg = new ShaderGenerator(
-                compilation,
-                vsName,
-                fsName,
-                backend);
-
-            ShaderGenerationResult result = sg.GenerateShaders();
-            IReadOnlyList<GeneratedShaderSet> sets = result.GetOutput(backend);
-            Assert.Equal(1, sets.Count);
-            GeneratedShaderSet set = sets[0];
-            ShaderModel shaderModel = set.Model;
-
-            if (vsName != null)
-            {
-                ShaderFunction vsFunction = shaderModel.GetFunction(vsName);
-                string vsCode = set.VertexShaderCode;
-                File.WriteAllText(@"C:\Users\raver\Documents\forward-vertex.glsl", vsCode);
-                GlsLangValidatorTool.AssertCompilesCode(vsCode, "vert", true);
-            }
-            if (fsName != null)
-            {
-                ShaderFunction fsFunction = shaderModel.GetFunction(fsName);
-                string fsCode = set.FragmentShaderCode;
-                File.WriteAllText(@"C:\Users\raver\Documents\forward-frag.glsl", fsCode);
-                GlsLangValidatorTool.AssertCompilesCode(fsCode, "frag", true);
-            }
-        }
     }
 }

--- a/src/ShaderGen.Tests/ShaderGeneratorTests.cs
+++ b/src/ShaderGen.Tests/ShaderGeneratorTests.cs
@@ -272,10 +272,11 @@ namespace ShaderGen.Tests
             Assert.Throws<ShaderGenerationException>(() => sg.GenerateShaders());
         }
 
+        [Fact]
         public void DummyTest()
         {
-            string vsName = "TestShaders.VeldridShaders.VertexAndFragment.VS";
-            string fsName = "TestShaders.VeldridShaders.VertexAndFragment.FS";
+            string vsName = "TestShaders.VertexAndFragment.VS";
+            string fsName = "TestShaders.VertexAndFragment.FS";
             Compilation compilation = TestUtil.GetTestProjectCompilation();
             using (TempFile fp = new TempFile())
             {

--- a/src/ShaderGen.Tests/ShaderModelTests.cs
+++ b/src/ShaderGen.Tests/ShaderModelTests.cs
@@ -28,7 +28,7 @@ namespace ShaderGen.Tests
             Assert.Equal(3, shaderModel.AllResources.Length);
             ShaderFunction vsEntry = shaderModel.GetFunction(functionName);
             Assert.Equal("VS", vsEntry.Name);
-            Assert.Equal(1, vsEntry.Parameters.Length);
+            Assert.Single(vsEntry.Parameters);
             Assert.True(vsEntry.IsEntryPoint);
             Assert.Equal(ShaderFunctionType.VertexEntryPoint, vsEntry.Type);
         }
@@ -96,7 +96,7 @@ namespace ShaderGen.Tests
             GeneratedShaderSet set = sets[0];
             ShaderModel shaderModel = set.Model;
 
-            Assert.Equal(1, shaderModel.AllResources.Length);
+            Assert.Single(shaderModel.AllResources);
             Assert.Equal(144, shaderModel.GetTypeSize(shaderModel.AllResources[0].ValueType));
         }
 

--- a/src/ShaderGen.Tests/TestAssets/Matrix4x4Members.cs
+++ b/src/ShaderGen.Tests/TestAssets/Matrix4x4Members.cs
@@ -3,7 +3,7 @@ using System.Numerics;
 
 namespace TestShaders
 {
-    internal class Matrix4x4Members
+    public class Matrix4x4Members
     {
         public Matrix4x4 InputMatrix;
 

--- a/src/ShaderGen.Tests/TestAssets/VeldridShaders/UIntVertexAttribs.cs
+++ b/src/ShaderGen.Tests/TestAssets/VeldridShaders/UIntVertexAttribs.cs
@@ -3,7 +3,7 @@ using System.Numerics;
 
 namespace TestShaders.VeldridShaders
 {
-    internal class UIntVertexAttribs
+    public class UIntVertexAttribs
     {
         public struct Vertex
         {


### PR DESCRIPTION
- Dummy test wasn't actually running because it wasn't marked as a [Fact]. Once I added that, it failed because the shader was not found. I am pretty sure that the one I chose is the correct shader.

- Single - This should be used instead of Equal to ensure a collection only has one element. Warning raised by xunit.

- Internal to Public changes - First, it's an easy fix for the warning that a field will never get set. Second, both of these are part of the unit tests, so their visibility doesn't much matter.

- All UnitTests pass