### PR TITLE
[WIP] Supporting invocation of static functions in separate files

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/CustomMethodCalls.cs
+++ b/src/ShaderGen.Tests/TestAssets/CustomMethodCalls.cs
@@ -1,6 +1,8 @@
 ﻿using ShaderGen;
 using System.Numerics;
 
+using static TestShaders.AnotherClass;
+
 namespace TestShaders
 {
     public class CustomMethodCalls
@@ -12,6 +14,7 @@ namespace TestShaders
             Position4 shuffled = ShufflePosition4(reversed);
             SystemPosition4 output;
             output.Position = shuffled.Position;
+            output.Position.X = CustomAbs(output.Position.X);
             return output;
         }
 

--- a/src/ShaderGen.Tests/TestAssets/CustomMethodCallsAnotherClass.cs
+++ b/src/ShaderGen.Tests/TestAssets/CustomMethodCallsAnotherClass.cs
@@ -1,0 +1,12 @@
+﻿using static ShaderGen.ShaderBuiltins;
+
+namespace TestShaders
+{
+    public static class AnotherClass
+    {
+        public static float CustomAbs(float v)
+        {
+            return Abs(v);
+        }
+    }
+}

--- a/src/ShaderGen/Glsl/GlslBackendBase.cs
+++ b/src/ShaderGen/Glsl/GlslBackendBase.cs
@@ -96,12 +96,11 @@ namespace ShaderGen.Glsl
                 Compilation,
                 new TypeAndMethodName { TypeName = function.DeclaringType, MethodName = function.Name });
             fcgd.GenerateFullGraph();
-            TypeAndMethodName[] orderedFunctionList = fcgd.GetOrderedCallList();
+            ShaderFunctionAndBlockSyntax[] orderedFunctionList = fcgd.GetOrderedCallList();
 
-            foreach (TypeAndMethodName name in orderedFunctionList)
+            foreach (ShaderFunctionAndBlockSyntax name in orderedFunctionList)
             {
-                ShaderFunctionAndBlockSyntax f = context.Functions.Single(
-                    sfabs => sfabs.Function.DeclaringType == name.TypeName && sfabs.Function.Name == name.MethodName);
+                ShaderFunctionAndBlockSyntax f = name;
                 if (!f.Function.IsEntryPoint)
                 {
                     MethodProcessResult processResult = new ShaderMethodVisitor(Compilation, setName, f.Function, this).VisitFunction(f.Block);

--- a/src/ShaderGen/Metal/MetalBackend.cs
+++ b/src/ShaderGen/Metal/MetalBackend.cs
@@ -220,13 +220,12 @@ namespace ShaderGen.Metal
                 new TypeAndMethodName { TypeName = function.DeclaringType, MethodName = function.Name });
             fcgd.GenerateFullGraph();
             // TODO: Necessary for Metal?
-            TypeAndMethodName[] orderedFunctionList = fcgd.GetOrderedCallList();
+            ShaderFunctionAndBlockSyntax[] orderedFunctionList = fcgd.GetOrderedCallList();
 
             StringBuilder functionsSB = new StringBuilder();
-            foreach (TypeAndMethodName name in orderedFunctionList)
+            foreach (ShaderFunctionAndBlockSyntax name in orderedFunctionList)
             {
-                ShaderFunctionAndBlockSyntax f = setContext.Functions.Single(
-                    sfabs => sfabs.Function.DeclaringType == name.TypeName && sfabs.Function.Name == name.MethodName);
+                ShaderFunctionAndBlockSyntax f = name;
                 if (!f.Function.IsEntryPoint)
                 {
                     MethodProcessResult processResult = new MetalMethodVisitor(Compilation, setName, f.Function, this).VisitFunction(f.Block);


### PR DESCRIPTION
(Will fixes #15, when it's finished.)

This [awful] code does seem to work [only for the HLSL backend]. This initial work is only meant for discussion. Once I know what I'm doing, I can do it properly.

@mellinoe, you mentioned in #15:

> Unless I'm missing something obvious, we should be able to more-or-less remove the first step. The only thing that step needs to discover is the entry point functions for the shader set (vertex/fragment). It doesn't need to track all of the other functions in the type, because they don't actually matter unless they are called by the entry function. If they are, they will be caught by the FunctionCallGraphDiscoverer later on. We can augment the FunctionCallGraphDiscoverer to output the full ShaderFunctionAndBlockSyntax information that is needed to generate the code in each backend.

`ShaderSyntaxWalker`, at least currently, seems to be necessary for more than just discovering the entry point. It calls `LanguageBackend.AddFunction`, and those functions are used later by `LanguageBackend.FormatInvocation`. I'm not sure how to refactor this, so at the moment I've just copied lots of code from `ShaderSyntaxWalker` into `FunctionCallGraphDiscoverer`, which is clearly not the right thing to do.

I got a bit bogged down while trying to work how this can all be refactored. I'm sorry to ask, but any chance you could point me in the right direction (again)? Were you expecting me to remove some of this code from `ShaderSyntaxWalker`, add it to `FunctionCallGraphDiscoverer`, and then fixup the callers? I'm not sure, but it seemed like `FunctionCallGraphDiscoverer` might be called too late for this to completely work.