### PR TITLE
Add support for pass-by-ref parameters

### DIFF
--- a/src/ShaderGen.Tests/ShaderGeneratorTests.cs
+++ b/src/ShaderGen.Tests/ShaderGeneratorTests.cs
@@ -43,6 +43,7 @@ namespace ShaderGen.Tests
             yield return new object[] { "TestShaders.VeldridShaders.UIntVertexAttribs.VS", null };
             yield return new object[] { "TestShaders.SwitchStatements.VS", null };
             yield return new object[] { "TestShaders.VariableTypes.VS", null };
+            yield return new object[] { "TestShaders.OutParameters.VS", null };
         }
 
         public static IEnumerable<object[]> ComputeShaders()

--- a/src/ShaderGen.Tests/TestAssets/OutParameters.cs
+++ b/src/ShaderGen.Tests/TestAssets/OutParameters.cs
@@ -1,0 +1,29 @@
+﻿using ShaderGen;
+using System.Numerics;
+
+namespace TestShaders
+{
+    public class OutParameters
+    {
+        private void MyFunc(Vector4 position, ref Vector2 xy, out Vector2 zw)
+        {
+            xy = position.XY();
+            zw = position.ZW();
+        }
+
+        [VertexShader]
+        public SystemPosition4 VS(Position4 input)
+        {
+            Vector2 xy = Vector2.Zero;
+            Vector2 zw;
+            MyFunc(input.Position, ref xy, out zw);
+
+            SystemPosition4 output;
+            output.Position.X = xy.X;
+            output.Position.Y = xy.Y;
+            output.Position.Z = zw.X;
+            output.Position.W = zw.Y;
+            return output;
+        }
+    }
+}

--- a/src/ShaderGen/Glsl/GlslBackendBase.cs
+++ b/src/ShaderGen/Glsl/GlslBackendBase.cs
@@ -378,7 +378,7 @@ namespace ShaderGen.Glsl
                 case ShaderGen.ParameterDirection.InOut:
                     return "inout";
                 default:
-                    return "in";
+                    return string.Empty;
             }
         }
 

--- a/src/ShaderGen/Glsl/GlslBackendBase.cs
+++ b/src/ShaderGen/Glsl/GlslBackendBase.cs
@@ -369,6 +369,19 @@ namespace ShaderGen.Glsl
             return $"layout(local_size_x = {groupCounts.X}, local_size_y = {groupCounts.Y}, local_size_z = {groupCounts.Z}) in;";
         }
 
+        internal override string ParameterDirection(ParameterDirection direction)
+        {
+            switch (direction)
+            {
+                case ShaderGen.ParameterDirection.Out:
+                    return "out";
+                case ShaderGen.ParameterDirection.InOut:
+                    return "inout";
+                default:
+                    return "in";
+            }
+        }
+
         private static readonly HashSet<string> s_glslKeywords = new HashSet<string>()
         {
             "input", "output",

--- a/src/ShaderGen/Hlsl/HlslBackend.cs
+++ b/src/ShaderGen/Hlsl/HlslBackend.cs
@@ -291,6 +291,19 @@ namespace ShaderGen.Hlsl
             return $"[numthreads({groupCounts.X}, {groupCounts.Y}, {groupCounts.Z})]";
         }
 
+        internal override string ParameterDirection(ParameterDirection direction)
+        {
+            switch (direction)
+            {
+                case ShaderGen.ParameterDirection.Out:
+                    return "out";
+                case ShaderGen.ParameterDirection.InOut:
+                    return "inout";
+                default:
+                    return "in";
+            }
+        }
+
         private struct HlslSemanticTracker
         {
             public int Position;

--- a/src/ShaderGen/Hlsl/HlslBackend.cs
+++ b/src/ShaderGen/Hlsl/HlslBackend.cs
@@ -300,7 +300,7 @@ namespace ShaderGen.Hlsl
                 case ShaderGen.ParameterDirection.InOut:
                     return "inout";
                 default:
-                    return "in";
+                    return string.Empty;
             }
         }
 

--- a/src/ShaderGen/LanguageBackend.cs
+++ b/src/ShaderGen/LanguageBackend.cs
@@ -347,5 +347,7 @@ namespace ShaderGen
 
             return literal;
         }
+
+        internal abstract string ParameterDirection(ParameterDirection direction);
     }
 }

--- a/src/ShaderGen/Metal/MetalBackend.cs
+++ b/src/ShaderGen/Metal/MetalBackend.cs
@@ -463,5 +463,17 @@ namespace ShaderGen.Metal
         {
             return identifier;
         }
+
+        internal override string ParameterDirection(ParameterDirection direction)
+        {
+            switch (direction)
+            {
+                case ShaderGen.ParameterDirection.Out:
+                case ShaderGen.ParameterDirection.InOut:
+                    return "&";
+                default:
+                    return string.Empty;
+            }
+        }
     }
 }

--- a/src/ShaderGen/Metal/MetalMethodVisitor.cs
+++ b/src/ShaderGen/Metal/MetalMethodVisitor.cs
@@ -34,7 +34,7 @@ namespace ShaderGen.Metal
 
         protected override string FormatParameter(ParameterDefinition pd)
         {
-            return $"{_backend.CSharpToShaderType(pd.Type.Name)} {_backend.CorrectIdentifier(pd.Name)}";
+            return $"{_backend.CSharpToShaderType(pd.Type.Name)} {_backend.ParameterDirection(pd.Direction)}{_backend.CorrectIdentifier(pd.Name)}";
         }
     }
 }

--- a/src/ShaderGen/ShaderMethodVisitor.cs
+++ b/src/ShaderGen/ShaderMethodVisitor.cs
@@ -106,7 +106,7 @@ namespace ShaderGen
             string rightExprType = Utilities.GetFullTypeName(GetModel(node), node.Right);
 
             string assignedValue = _backend.CorrectAssignedValue(leftExprType, rightExpr, rightExprType);
-            return $"{leftExpr} {token} {assignedValue};";
+            return $"{leftExpr} {token} {assignedValue}";
         }
 
         public override string VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
@@ -149,7 +149,7 @@ namespace ShaderGen
 
         public override string VisitExpressionStatement(ExpressionStatementSyntax node)
         {
-            return Visit(node.Expression);
+            return Visit(node.Expression) + ";";
         }
 
         public override string VisitReturnStatement(ReturnStatementSyntax node)
@@ -479,7 +479,7 @@ namespace ShaderGen
 
         protected virtual string FormatParameter(ParameterDefinition pd)
         {
-            return $"{_backend.CSharpToShaderType(pd.Type.Name)} {_backend.CorrectIdentifier(pd.Name)}";
+            return $"{_backend.ParameterDirection(pd.Direction)} {_backend.CSharpToShaderType(pd.Type.Name)} {_backend.CorrectIdentifier(pd.Name)}";
         }
 
         private InvocationParameterInfo[] GetParameterInfos(ArgumentListSyntax argumentList)


### PR DESCRIPTION
Compiles to `out` / `inout` in HLSL and GLSL, and `&` in MetalSL. I haven't run the tests on a Mac - I really should set myself up to be able to do that.

(On a related note, it would be really cool to run the HLSL and GLSL tests on AppVeyor, and the Metal tests on a Mac agent on Travis.)

I don't know how you feel about adding `in` to all pass-by-value parameters in HLSL and GLSL - we obviously don't need to do that.