### PR TITLE
Update readme example and its output

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ Writing shader code in C# could have quite a few benefits:
 
 ## Example Shader
 
-**NOTE: The examples below are a bit out of date with regards to the current output of the library. This is still a decent approximation of what the output looks like, though.**
-
 Here is an example vertex and fragment shader, written in C# with ShaderGen:
 
 ```C#
@@ -74,13 +72,7 @@ struct MinExample_VertexInput
 
 struct MinExample_FragmentInput
 {
-    float4 Position : POSITION0;
-    float2 TextureCoord : TEXCOORD0;
-};
-
-struct MinExample_FragmentInput__FRAGSEMANTICS
-{
-    float4 Position : SV_POSITION;
+    float4 Position : SV_Position;
     float2 TextureCoord : TEXCOORD0;
 };
 
@@ -99,7 +91,7 @@ cbuffer WorldBuffer : register(b2)
     float4x4 World;
 }
 
-MinExample_FragmentInput__FRAGSEMANTICS VertexShaderFunc(MinExample_VertexInput input)
+MinExample_FragmentInput VertexShaderFunc( MinExample_VertexInput input)
 {
     MinExample_FragmentInput output;
     float4 worldPosition = mul(World, float4(input.Position, 1));
@@ -112,16 +104,23 @@ MinExample_FragmentInput__FRAGSEMANTICS VertexShaderFunc(MinExample_VertexInput 
 
 HLSL Fragment Shader
 ```HLSL
-struct MinExample_FragmentInput__FRAGSEMANTICS
+struct MinExample_VertexInput
 {
-    float4 Position : SV_POSITION;
+    float3 Position : POSITION0;
+    float2 TextureCoord : TEXCOORD0;
+};
+
+struct MinExample_FragmentInput
+{
+    float4 Position : SV_Position;
     float2 TextureCoord : TEXCOORD0;
 };
 
 Texture2D SurfaceTexture : register(t0);
+
 SamplerState Sampler : register(s0);
 
-float4 FragmentShaderFunc(MinExample_FragmentInput__FRAGSEMANTICS input) : SV_Target
+float4 FragmentShaderFunc( MinExample_FragmentInput input) : SV_Target
 {
     return SurfaceTexture.Sample(Sampler, input.TextureCoord);
 }
@@ -144,32 +143,37 @@ struct MinExample_FragmentInput
     vec2 TextureCoord;
 };
 
-layout(binding = 0) uniform ProjectionBuffer
+layout(set = 0, binding = 0) uniform Projection
 {
-    mat4 Projection;
-};
-layout(binding = 1) uniform ViewBuffer
-{
-    mat4 View;
-};
-layout(binding = 2) uniform WorldBuffer
-{
-    mat4 World;
+    mat4 field_Projection;
 };
 
-MinExample_FragmentInput VertexShaderFunc(MinExample_VertexInput input_)
+layout(set = 0, binding = 1) uniform View
+{
+    mat4 field_View;
+};
+
+layout(set = 0, binding = 2) uniform World
+{
+    mat4 field_World;
+};
+
+layout(set = 0, binding = 3) uniform texture2D SurfaceTexture;
+layout(set = 0, binding = 4) uniform sampler Sampler;
+MinExample_FragmentInput VertexShaderFunc( MinExample_VertexInput input_)
 {
     MinExample_FragmentInput output_;
-    vec4 worldPosition = World * vec4(input_.Position, 1);
-    vec4 viewPosition = View * worldPosition;
-    output_.Position = Projection * viewPosition;
+    vec4 worldPosition = field_World * vec4(input_.Position, 1);
+    vec4 viewPosition = field_View * worldPosition;
+    output_.Position = field_Projection * viewPosition;
     output_.TextureCoord = input_.TextureCoord;
     return output_;
 }
 
+
 layout(location = 0) in vec3 Position;
 layout(location = 1) in vec2 TextureCoord;
-layout(location = 0) out vec2 out_TextureCoord;
+layout(location = 0) out vec2 fsin_0;
 
 void main()
 {
@@ -177,8 +181,9 @@ void main()
     input_.Position = Position;
     input_.TextureCoord = TextureCoord;
     MinExample_FragmentInput output_ = VertexShaderFunc(input_);
-    out_TextureCoord = output_.TextureCoord;
+    fsin_0 = output_.TextureCoord;
     gl_Position = output_.Position;
+        gl_Position.y = -gl_Position.y; // Correct for Vulkan clip coordinates
 }
 ```
 
@@ -187,6 +192,11 @@ GLSL (450) Fragment Shader
 #version 450
 #extension GL_ARB_separate_shader_objects : enable
 #extension GL_ARB_shading_language_420pack : enable
+struct MinExample_VertexInput
+{
+    vec3 Position;
+    vec2 TextureCoord;
+};
 
 struct MinExample_FragmentInput
 {
@@ -194,23 +204,37 @@ struct MinExample_FragmentInput
     vec2 TextureCoord;
 };
 
-layout(binding = 3) uniform texture2D SurfaceTexture;
-layout(binding = 4) uniform sampler Sampler;
+layout(set = 0, binding = 0) uniform Projection
+{
+    mat4 field_Projection;
+};
 
-vec4 FragmentShaderFunc(MinExample_FragmentInput input_)
+layout(set = 0, binding = 1) uniform View
+{
+    mat4 field_View;
+};
+
+layout(set = 0, binding = 2) uniform World
+{
+    mat4 field_World;
+};
+
+layout(set = 0, binding = 3) uniform texture2D SurfaceTexture;
+layout(set = 0, binding = 4) uniform sampler Sampler;
+vec4 FragmentShaderFunc( MinExample_FragmentInput input_)
 {
     return texture(sampler2D(SurfaceTexture, Sampler), input_.TextureCoord);
 }
 
-layout(location = 0) in vec4 Position;
-layout(location = 1) in vec2 TextureCoord;
+
+layout(location = 0) in vec2 fsin_0;
 layout(location = 0) out vec4 _outputColor_;
 
 void main()
 {
     MinExample_FragmentInput input_;
-    input_.Position = Position;
-    input_.TextureCoord = TextureCoord;
+    input_.Position = gl_FragCoord;
+    input_.TextureCoord = fsin_0;
     vec4 output_ = FragmentShaderFunc(input_);
     _outputColor_ = output_;
 }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ public class MinExample
 
     public struct FragmentInput
     {
-        [PositionSemantic] public Vector4 Position;
+        [SystemPositionSemanticAttribute] public Vector4 Position;
         [TextureCoordinateSemantic] public Vector2 TextureCoord;
     }
 


### PR DESCRIPTION
This change updates the example in the readme to use the `SystemPosition` semantic (which was introduced in fb46362c5df8d4ec63fbffc161ed5e70071e1c59.)

Since I had them on hand, I've also gone ahead and updated the example shader's HLSL/GLSL outputs using the output from Veldrid MyGet version 1.2.0-gee66e61d2a.