### PR TITLE
Allow SamplerResource-typed parameters

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/TextureSamplerFragment.cs
+++ b/src/ShaderGen.Tests/TestAssets/TextureSamplerFragment.cs
@@ -22,7 +22,13 @@ namespace TestShaders
         public Vector4 FS(FragmentInput input)
         {
             Vector4 cubeSample = Sample(TexCube, Sampler, new Vector3(1, 2, 3));
+            Vector4 calledMethodSample = SampleTexture(Tex2D, Sampler);
             return Sample(Tex2D, Sampler, input.TextureCoordinate);
+        }
+
+        private Vector4 SampleTexture(Texture2DResource myTexture, SamplerResource mySampler)
+        {
+            return Sample(myTexture, mySampler, Vector2.Zero);
         }
     }
 }

--- a/src/ShaderGen/Hlsl/HlslKnownTypes.cs
+++ b/src/ShaderGen/Hlsl/HlslKnownTypes.cs
@@ -14,6 +14,7 @@ namespace ShaderGen.Hlsl
             { "System.Numerics.Vector4", "float4" },
             { "System.Numerics.Matrix4x4", "float4x4" },
             { "System.Void", "void" },
+            { "ShaderGen.SamplerResource", "SamplerState" },
             { "ShaderGen.Texture2DResource", "Texture2D" },
             { "ShaderGen.TextureCubeResource", "TextureCube" },
             { "System.Boolean", "bool" },


### PR DESCRIPTION
Before this change, trying to use `ShaderResource` as a parameter type resulted in invalid HLSL (it generated a unique type name instead of recognising it as a `SamplerState`).