### PR TITLE
Allow StructuredBuffers to be used as parameter types

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/SimpleCompute.cs
+++ b/src/ShaderGen.Tests/TestAssets/SimpleCompute.cs
@@ -16,8 +16,14 @@ namespace TestShaders
         {
             StructuredInOut[DispatchThreadID.X] = StructuredInput[DispatchThreadID.Y];
             StructuredInOut[DispatchThreadID.Y].Z = 1;
+            StructuredInOut[DispatchThreadID.Z] = GetValue(StructuredInput);
 
             RWBufferWithCustomStruct[0].Color = new Vector3(1, 2, 3);
+        }
+
+        private Vector4 GetValue(StructuredBuffer<Vector4> myBuffer)
+        {
+            return myBuffer[0];
         }
     }
 }

--- a/src/ShaderGen/Hlsl/HlslKnownTypes.cs
+++ b/src/ShaderGen/Hlsl/HlslKnownTypes.cs
@@ -15,6 +15,7 @@ namespace ShaderGen.Hlsl
             { "System.Numerics.Matrix4x4", "float4x4" },
             { "System.Void", "void" },
             { "ShaderGen.SamplerResource", "SamplerState" },
+            { "ShaderGen.StructuredBuffer", "StructuredBuffer" },
             { "ShaderGen.Texture2DResource", "Texture2D" },
             { "ShaderGen.TextureCubeResource", "TextureCube" },
             { "System.Boolean", "bool" },
@@ -28,6 +29,15 @@ namespace ShaderGen.Hlsl
 
         public static string GetMappedName(string name)
         {
+            var genericParameterIndex = name.IndexOf("<");
+            if (genericParameterIndex > -1)
+            {
+                string originalType = name.Substring(0, genericParameterIndex);
+                string genericParameter = name.Substring(genericParameterIndex + 1, name.IndexOf(">") - (genericParameterIndex + 1));
+
+                return GetMappedName(originalType) + "<" + GetMappedName(genericParameter) + ">";
+            }
+
             if (s_knownTypes.TryGetValue(name, out string mapped))
             {
                 return mapped;

--- a/src/ShaderGen/Utilities.cs
+++ b/src/ShaderGen/Utilities.cs
@@ -65,6 +65,13 @@ namespace ShaderGen
                 return string.Empty;
             }
 
+            if (s is INamedTypeSymbol nts && nts.Arity > 0)
+            {
+                return s.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                    .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)
+                    .RemoveMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+            }
+
             StringBuilder sb = new StringBuilder(s.MetadataName);
             ISymbol last = s;
 


### PR DESCRIPTION
This does for `StructuredBuffer<T>` what #20 did for `SamplerState`.

It's rather hacky, because of the generic parameter. To meaningfully improve on it, we'd need to preserve richer type information than we currently do. Instead of passing a `string` around representing the type, we'd need to preserve more of the original type information.

Do you want to do this larger refactoring now, or is this good enough for now?