### PR TITLE
Add support for expression-bodied methods

### DIFF
--- a/src/ShaderGen.Tests/ShaderGeneratorTests.cs
+++ b/src/ShaderGen.Tests/ShaderGeneratorTests.cs
@@ -44,6 +44,8 @@ namespace ShaderGen.Tests
             yield return new object[] { "TestShaders.SwitchStatements.VS", null };
             yield return new object[] { "TestShaders.VariableTypes.VS", null };
             yield return new object[] { "TestShaders.OutParameters.VS", null };
+            yield return new object[] { null, "TestShaders.ExpressionBodiedMethods.ExpressionBodyWithReturn" };
+            yield return new object[] { null, "TestShaders.ExpressionBodiedMethods.ExpressionBodyWithoutReturn" };
         }
 
         public static IEnumerable<object[]> ComputeShaders()

--- a/src/ShaderGen.Tests/TestAssets/ExpressionBodiedMethods.cs
+++ b/src/ShaderGen.Tests/TestAssets/ExpressionBodiedMethods.cs
@@ -1,0 +1,16 @@
+﻿using ShaderGen;
+using System.Numerics;
+
+namespace TestShaders
+{
+    public class ExpressionBodiedMethods
+    {
+        [FragmentShader]
+        public Vector4 ExpressionBodyWithReturn()
+            => new Vector4(0f, 0f, 0f, 1f);
+
+        [FragmentShader]
+        public void ExpressionBodyWithoutReturn()
+            => new Vector4(0f, 0f, 0f, 1f);
+    }
+}

--- a/src/ShaderGen/FunctionCallGraphDiscoverer.cs
+++ b/src/ShaderGen/FunctionCallGraphDiscoverer.cs
@@ -23,16 +23,16 @@ namespace ShaderGen
             _nodesByName.Add(rootMethod, _rootNode);
         }
 
-        public ShaderFunctionAndBlockSyntax[] GetOrderedCallList()
+        public ShaderFunctionAndMethodDeclarationSyntax[] GetOrderedCallList()
         {
-            HashSet<ShaderFunctionAndBlockSyntax> result = new HashSet<ShaderFunctionAndBlockSyntax>();
+            HashSet<ShaderFunctionAndMethodDeclarationSyntax> result = new HashSet<ShaderFunctionAndMethodDeclarationSyntax>();
             TraverseNode(result, _rootNode);
             return result.ToArray();
         }
 
-        private void TraverseNode(HashSet<ShaderFunctionAndBlockSyntax> result, CallGraphNode node)
+        private void TraverseNode(HashSet<ShaderFunctionAndMethodDeclarationSyntax> result, CallGraphNode node)
         {
-            foreach (ShaderFunctionAndBlockSyntax existing in result)
+            foreach (ShaderFunctionAndMethodDeclarationSyntax existing in result)
             {
                 if (node.Parents.Any(cgn => cgn.Name.Equals(existing)))
                 {
@@ -45,7 +45,7 @@ namespace ShaderGen
                 TraverseNode(result, child);
             }
 
-            ShaderFunctionAndBlockSyntax sfab = Utilities.GetShaderFunction(node.Declaration, Compilation, false);
+            ShaderFunctionAndMethodDeclarationSyntax sfab = Utilities.GetShaderFunction(node.Declaration, Compilation, false);
 
             result.Add(sfab);
         }

--- a/src/ShaderGen/Glsl/GlslBackendBase.cs
+++ b/src/ShaderGen/Glsl/GlslBackendBase.cs
@@ -99,7 +99,7 @@ namespace ShaderGen.Glsl
             {
                 if (!f.Function.IsEntryPoint)
                 {
-                    MethodProcessResult processResult = new ShaderMethodVisitor(Compilation, setName, f.Function, this).VisitFunction(f.Block);
+                    MethodProcessResult processResult = new ShaderMethodVisitor(Compilation, setName, f.Function, this).VisitFunction(f.MethodDeclaration);
                     foreach (ResourceDefinition rd in processResult.ResourcesUsed)
                     {
                         resourcesUsed.Add(rd);
@@ -109,7 +109,7 @@ namespace ShaderGen.Glsl
             }
 
             MethodProcessResult result = new ShaderMethodVisitor(Compilation, setName, entryPoint.Function, this)
-                .VisitFunction(entryPoint.Block);
+                .VisitFunction(entryPoint.MethodDeclaration);
             foreach (ResourceDefinition rd in result.ResourcesUsed)
             {
                 resourcesUsed.Add(rd);

--- a/src/ShaderGen/Glsl/GlslBackendBase.cs
+++ b/src/ShaderGen/Glsl/GlslBackendBase.cs
@@ -51,7 +51,7 @@ namespace ShaderGen.Glsl
             StringBuilder sb = new StringBuilder();
             HashSet<ResourceDefinition> resourcesUsed = new HashSet<ResourceDefinition>();
 
-            ShaderFunctionAndBlockSyntax entryPoint = context.Functions.SingleOrDefault(
+            ShaderFunctionAndMethodDeclarationSyntax entryPoint = context.Functions.SingleOrDefault(
                 sfabs => sfabs.Function.Name == function.Name);
             if (entryPoint == null)
             {
@@ -95,7 +95,7 @@ namespace ShaderGen.Glsl
                 }
             }
 
-            foreach (ShaderFunctionAndBlockSyntax f in entryPoint.OrderedFunctionList)
+            foreach (ShaderFunctionAndMethodDeclarationSyntax f in entryPoint.OrderedFunctionList)
             {
                 if (!f.Function.IsEntryPoint)
                 {

--- a/src/ShaderGen/Hlsl/HlslBackend.cs
+++ b/src/ShaderGen/Hlsl/HlslBackend.cs
@@ -140,7 +140,7 @@ namespace ShaderGen.Hlsl
             HashSet<ResourceDefinition> resourcesUsed = new HashSet<ResourceDefinition>();
 
             BackendContext setContext = GetContext(setName);
-            ShaderFunctionAndBlockSyntax entryPoint = setContext.Functions.SingleOrDefault(
+            ShaderFunctionAndMethodDeclarationSyntax entryPoint = setContext.Functions.SingleOrDefault(
                 sfabs => sfabs.Function.Name == function.Name);
             if (entryPoint == null)
             {
@@ -160,7 +160,7 @@ namespace ShaderGen.Hlsl
                 .Select(g => g.ToArray()).ToList();
 
             StringBuilder functionsSB = new StringBuilder();
-            foreach (ShaderFunctionAndBlockSyntax f in entryPoint.OrderedFunctionList)
+            foreach (ShaderFunctionAndMethodDeclarationSyntax f in entryPoint.OrderedFunctionList)
             {
                 if (!f.Function.IsEntryPoint)
                 {

--- a/src/ShaderGen/Hlsl/HlslBackend.cs
+++ b/src/ShaderGen/Hlsl/HlslBackend.cs
@@ -164,7 +164,7 @@ namespace ShaderGen.Hlsl
             {
                 if (!f.Function.IsEntryPoint)
                 {
-                    MethodProcessResult processResult = new HlslMethodVisitor(Compilation, setName, f.Function, this).VisitFunction(f.Block);
+                    MethodProcessResult processResult = new HlslMethodVisitor(Compilation, setName, f.Function, this).VisitFunction(f.MethodDeclaration);
                     foreach (ResourceDefinition rd in processResult.ResourcesUsed)
                     {
                         resourcesUsed.Add(rd);
@@ -174,7 +174,7 @@ namespace ShaderGen.Hlsl
             }
 
             MethodProcessResult result = new HlslMethodVisitor(Compilation, setName, entryPoint.Function, this)
-                .VisitFunction(entryPoint.Block);
+                .VisitFunction(entryPoint.MethodDeclaration);
             foreach (ResourceDefinition rd in result.ResourcesUsed)
             {
                 resourcesUsed.Add(rd);

--- a/src/ShaderGen/LanguageBackend.cs
+++ b/src/ShaderGen/LanguageBackend.cs
@@ -15,7 +15,7 @@ namespace ShaderGen
         {
             internal List<StructureDefinition> Structures { get; } = new List<StructureDefinition>();
             internal List<ResourceDefinition> Resources { get; } = new List<ResourceDefinition>();
-            internal List<ShaderFunctionAndBlockSyntax> Functions { get; } = new List<ShaderFunctionAndBlockSyntax>();
+            internal List<ShaderFunctionAndMethodDeclarationSyntax> Functions { get; } = new List<ShaderFunctionAndMethodDeclarationSyntax>();
         }
 
         internal Dictionary<string, BackendContext> Contexts = new Dictionary<string, BackendContext>();
@@ -75,7 +75,7 @@ namespace ShaderGen
             ResourceDefinition[] computeResources = null;
 
             // HACK: Discover all method input structures.
-            foreach (ShaderFunctionAndBlockSyntax sf in context.Functions.ToArray())
+            foreach (ShaderFunctionAndMethodDeclarationSyntax sf in context.Functions.ToArray())
             {
                 if (sf.Function.IsEntryPoint)
                 {
@@ -193,7 +193,7 @@ namespace ShaderGen
             GetContext(setName).Resources.Add(rd);
         }
 
-        internal virtual void AddFunction(string setName, ShaderFunctionAndBlockSyntax sf)
+        internal virtual void AddFunction(string setName, ShaderFunctionAndMethodDeclarationSyntax sf)
         {
             if (sf == null)
             {
@@ -223,7 +223,7 @@ namespace ShaderGen
             Debug.Assert(method != null);
             Debug.Assert(parameterInfos != null);
 
-            ShaderFunctionAndBlockSyntax function = GetContext(setName).Functions
+            ShaderFunctionAndMethodDeclarationSyntax function = GetContext(setName).Functions
                 .SingleOrDefault(
                     sfabs => sfabs.Function.DeclaringType == type && sfabs.Function.Name == method
                         && parameterInfos.Length == sfabs.Function.Parameters.Length);

--- a/src/ShaderGen/Metal/MetalBackend.cs
+++ b/src/ShaderGen/Metal/MetalBackend.cs
@@ -194,7 +194,7 @@ namespace ShaderGen.Metal
             StringBuilder sb = new StringBuilder();
             HashSet<ResourceDefinition> resourcesUsed = new HashSet<ResourceDefinition>();
             BackendContext setContext = GetContext(setName);
-            ShaderFunctionAndBlockSyntax entryPoint = setContext.Functions.SingleOrDefault(
+            ShaderFunctionAndMethodDeclarationSyntax entryPoint = setContext.Functions.SingleOrDefault(
                 sfabs => sfabs.Function.Name == function.Name);
             if (entryPoint == null)
             {
@@ -216,7 +216,7 @@ namespace ShaderGen.Metal
             }
 
             StringBuilder functionsSB = new StringBuilder();
-            foreach (ShaderFunctionAndBlockSyntax f in entryPoint.OrderedFunctionList)
+            foreach (ShaderFunctionAndMethodDeclarationSyntax f in entryPoint.OrderedFunctionList)
             {
                 if (!f.Function.IsEntryPoint)
                 {

--- a/src/ShaderGen/Metal/MetalBackend.cs
+++ b/src/ShaderGen/Metal/MetalBackend.cs
@@ -220,7 +220,7 @@ namespace ShaderGen.Metal
             {
                 if (!f.Function.IsEntryPoint)
                 {
-                    MethodProcessResult processResult = new MetalMethodVisitor(Compilation, setName, f.Function, this).VisitFunction(f.Block);
+                    MethodProcessResult processResult = new MetalMethodVisitor(Compilation, setName, f.Function, this).VisitFunction(f.MethodDeclaration);
                     foreach (ResourceDefinition rd in processResult.ResourcesUsed)
                     {
                         resourcesUsed.Add(rd);
@@ -230,7 +230,7 @@ namespace ShaderGen.Metal
             }
 
             MethodProcessResult entryResult = new MetalMethodVisitor(Compilation, setName, entryPoint.Function, this)
-                .VisitFunction(entryPoint.Block);
+                .VisitFunction(entryPoint.MethodDeclaration);
             foreach (ResourceDefinition rd in entryResult.ResourcesUsed)
             {
                 resourcesUsed.Add(rd);

--- a/src/ShaderGen/ShaderFunctionAndBlockSyntax.cs
+++ b/src/ShaderGen/ShaderFunctionAndBlockSyntax.cs
@@ -6,17 +6,17 @@ namespace ShaderGen
     public class ShaderFunctionAndBlockSyntax : IEquatable<ShaderFunctionAndBlockSyntax>
     {
         public ShaderFunction Function { get; }
-        public BlockSyntax Block { get; }
+        public MethodDeclarationSyntax MethodDeclaration { get; }
 
         /// <summary>
         /// Only present for entry-point functions.
         /// </summary>
         public ShaderFunctionAndBlockSyntax[] OrderedFunctionList { get; }
 
-        public ShaderFunctionAndBlockSyntax(ShaderFunction function, BlockSyntax block, ShaderFunctionAndBlockSyntax[] orderedFunctionList)
+        public ShaderFunctionAndBlockSyntax(ShaderFunction function, MethodDeclarationSyntax methodDeclaration, ShaderFunctionAndBlockSyntax[] orderedFunctionList)
         {
             Function = function;
-            Block = block;
+            MethodDeclaration = methodDeclaration;
             OrderedFunctionList = orderedFunctionList;
         }
 

--- a/src/ShaderGen/ShaderFunctionAndMethodDeclarationSyntax.cs
+++ b/src/ShaderGen/ShaderFunctionAndMethodDeclarationSyntax.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace ShaderGen
 {
-    public class ShaderFunctionAndBlockSyntax : IEquatable<ShaderFunctionAndBlockSyntax>
+    public class ShaderFunctionAndMethodDeclarationSyntax : IEquatable<ShaderFunctionAndMethodDeclarationSyntax>
     {
         public ShaderFunction Function { get; }
         public MethodDeclarationSyntax MethodDeclaration { get; }
@@ -11,9 +11,9 @@ namespace ShaderGen
         /// <summary>
         /// Only present for entry-point functions.
         /// </summary>
-        public ShaderFunctionAndBlockSyntax[] OrderedFunctionList { get; }
+        public ShaderFunctionAndMethodDeclarationSyntax[] OrderedFunctionList { get; }
 
-        public ShaderFunctionAndBlockSyntax(ShaderFunction function, MethodDeclarationSyntax methodDeclaration, ShaderFunctionAndBlockSyntax[] orderedFunctionList)
+        public ShaderFunctionAndMethodDeclarationSyntax(ShaderFunction function, MethodDeclarationSyntax methodDeclaration, ShaderFunctionAndMethodDeclarationSyntax[] orderedFunctionList)
         {
             Function = function;
             MethodDeclaration = methodDeclaration;
@@ -22,7 +22,7 @@ namespace ShaderGen
 
         public override string ToString() => Function.ToString();
 
-        public bool Equals(ShaderFunctionAndBlockSyntax other)
+        public bool Equals(ShaderFunctionAndMethodDeclarationSyntax other)
         {
             return Function.DeclaringType == other.Function.DeclaringType
                 && Function.Name == other.Function.Name;

--- a/src/ShaderGen/ShaderSyntaxWalker.cs
+++ b/src/ShaderGen/ShaderSyntaxWalker.cs
@@ -29,7 +29,7 @@ namespace ShaderGen
 
         public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
         {
-            ShaderFunctionAndBlockSyntax sfab = Utilities.GetShaderFunction(node, _compilation, true);
+            ShaderFunctionAndMethodDeclarationSyntax sfab = Utilities.GetShaderFunction(node, _compilation, true);
             foreach (LanguageBackend b in _backends)
             {
                 b.AddFunction(_shaderSet.Name, sfab);

--- a/src/ShaderGen/Utilities.cs
+++ b/src/ShaderGen/Utilities.cs
@@ -216,7 +216,7 @@ namespace ShaderGen
             return string.Join(separator, value.Where(s => !string.IsNullOrEmpty(s)));
         }
 
-        internal static ShaderFunctionAndBlockSyntax GetShaderFunction(
+        internal static ShaderFunctionAndMethodDeclarationSyntax GetShaderFunction(
             MethodDeclarationSyntax node, 
             Compilation compilation,
             bool generateOrderedFunctionList)
@@ -268,7 +268,7 @@ namespace ShaderGen
                 type,
                 computeGroupCounts);
 
-            ShaderFunctionAndBlockSyntax[] orderedFunctionList;
+            ShaderFunctionAndMethodDeclarationSyntax[] orderedFunctionList;
             if (type != ShaderFunctionType.Normal && generateOrderedFunctionList)
             {
                 FunctionCallGraphDiscoverer fcgd = new FunctionCallGraphDiscoverer(
@@ -279,10 +279,10 @@ namespace ShaderGen
             }
             else
             {
-                orderedFunctionList = new ShaderFunctionAndBlockSyntax[0];
+                orderedFunctionList = new ShaderFunctionAndMethodDeclarationSyntax[0];
             }
 
-            return new ShaderFunctionAndBlockSyntax(sf, node, orderedFunctionList);
+            return new ShaderFunctionAndMethodDeclarationSyntax(sf, node, orderedFunctionList);
         }
 
         private static uint GetAttributeArgumentUIntValue(AttributeSyntax attr, int index)

--- a/src/ShaderGen/Utilities.cs
+++ b/src/ShaderGen/Utilities.cs
@@ -282,7 +282,7 @@ namespace ShaderGen
                 orderedFunctionList = new ShaderFunctionAndBlockSyntax[0];
             }
 
-            return new ShaderFunctionAndBlockSyntax(sf, node.Body, orderedFunctionList);
+            return new ShaderFunctionAndBlockSyntax(sf, node, orderedFunctionList);
         }
 
         private static uint GetAttributeArgumentUIntValue(AttributeSyntax attr, int index)


### PR DESCRIPTION
This pull request adds support for expression-bodied methods.

Before this change, using expression-bodied methods would crash `ShaderMethodVisitor` since the method's body was null.

This entailed the following changes:
* `ShaderFunctionAndBlockSyntax` is now `ShaderFunctionAndMethodDeclarationSyntax` and as the name implied, it contains a reference to the method declaration instead of the block body.
* `ShaderMethodVisitor.VisitFunction` now takes a `MethodDeclarationSyntax` instead of a `BlockSyntax` and uses either `VisitBlock` or `VisitArrowExpressionClause` depending on the method type.
* `VisitArrowExpressionClause` was introduced to support expression-bodied methods. It automatically decides if it should act like a return statement or or a expression statement based on the method's return type.

I've also added some expression-bodied shaders to the `ShaderGeneratorTests.ShaderSets` list as a basic smoke test.

It may be easier to review changes by reading db24a3837226ad3036cfa63bdded97345025c264 in isolation since it does not include the `ShaderFunctionAnd...Syntax` rename.