### PR TITLE
Prevent duplicate function definitions when custom functions are called from multiple places

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/CustomMethodCalls.cs
+++ b/src/ShaderGen.Tests/TestAssets/CustomMethodCalls.cs
@@ -15,6 +15,7 @@ namespace TestShaders
             SystemPosition4 output;
             output.Position = shuffled.Position;
             output.Position.X = CustomAbs(output.Position.X);
+            output.Position.X += HelperMethod(output.Position.X);
             return output;
         }
 

--- a/src/ShaderGen.Tests/TestAssets/CustomMethodCallsAnotherClass.cs
+++ b/src/ShaderGen.Tests/TestAssets/CustomMethodCallsAnotherClass.cs
@@ -6,6 +6,11 @@ namespace TestShaders
     {
         public static float CustomAbs(float v)
         {
+            return HelperMethod(v);
+        }
+
+        public static float HelperMethod(float v)
+        {
             return Abs(v);
         }
     }

--- a/src/ShaderGen/ShaderFunctionAndMethodDeclarationSyntax.cs
+++ b/src/ShaderGen/ShaderFunctionAndMethodDeclarationSyntax.cs
@@ -27,5 +27,13 @@ namespace ShaderGen
             return Function.DeclaringType == other.Function.DeclaringType
                 && Function.Name == other.Function.Name;
         }
+
+        public override int GetHashCode()
+        {
+            var hashCode = 1204124163;
+            hashCode = hashCode * -1521134295 + Function.DeclaringType.GetHashCode();
+            hashCode = hashCode * -1521134295 + Function.Name.GetHashCode();
+            return hashCode;
+        }
     }
 }


### PR DESCRIPTION
Builds on #21. That should be merged before this one.

Without this fix, if functions are called from multiple different methods, they will be written out multiple times to the resulting shader, resulting in errors because of duplicate function definitions.