### PR TITLE
Fix bug when using a hex constant that ends with F

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/VariableTypes.cs
+++ b/src/ShaderGen.Tests/TestAssets/VariableTypes.cs
@@ -21,7 +21,7 @@ namespace TestShaders
             }
             float l = 0;
             uint l2 = (uint) l;
-            uint l3 = 0xFF;
+            uint l3 = 0xFFu;
             return output;
         }
 

--- a/src/ShaderGen.Tests/TestAssets/VariableTypes.cs
+++ b/src/ShaderGen.Tests/TestAssets/VariableTypes.cs
@@ -21,6 +21,7 @@ namespace TestShaders
             }
             float l = 0;
             uint l2 = (uint) l;
+            uint l3 = 0xFF;
             return output;
         }
 

--- a/src/ShaderGen/LanguageBackend.cs
+++ b/src/ShaderGen/LanguageBackend.cs
@@ -341,7 +341,7 @@ namespace ShaderGen
 
         internal string CorrectLiteral(string literal)
         {
-            if (literal.EndsWith("f", StringComparison.OrdinalIgnoreCase))
+            if (!literal.StartsWith("0x", StringComparison.OrdinalIgnoreCase) && literal.EndsWith("f", StringComparison.OrdinalIgnoreCase))
             {
                 if (!literal.Contains("."))
                 {


### PR DESCRIPTION
Without this, `0xFF` is incorrectly "converted" to a floating-point number using the not-at-all-hacky code in `CorrectLiteral` :)