### PR TITLE
Validate that Ddx and Ddy are not used in vertex or compute shader entry point functions

### DIFF
--- a/src/ShaderGen/ShaderMethodVisitor.cs
+++ b/src/ShaderGen/ShaderMethodVisitor.cs
@@ -273,7 +273,7 @@ namespace ShaderGen
         {
             if (name == nameof(ShaderBuiltins.Ddx) || name == nameof(ShaderBuiltins.Ddy))
             {
-                if (_shaderFunction.Type != ShaderFunctionType.FragmentEntryPoint)
+                if (_shaderFunction.Type == ShaderFunctionType.VertexEntryPoint || _shaderFunction.Type == ShaderFunctionType.ComputeEntryPoint)
                 {
                     throw new ShaderGenerationException("Ddx and Ddy can only be used within Fragment shaders.");
                 }


### PR DESCRIPTION
(rather than previous validation, which didn't work when Ddx or Ddy were used in helper functions called by a fragment shader)