### PR TITLE
Fix StructuredBuffer usage in Metal backend

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/SimpleCompute.cs
+++ b/src/ShaderGen.Tests/TestAssets/SimpleCompute.cs
@@ -6,7 +6,7 @@ namespace TestShaders
 {
     public class SimpleCompute
     {
-        public StructuredBuffer<Vector4> StructuredInput;
+        public StructuredBuffer<Matrix4x4> StructuredInput;
         public RWStructuredBuffer<Vector4> StructuredInOut;
 
         public RWStructuredBuffer<PointLightInfo> RWBufferWithCustomStruct;
@@ -14,7 +14,8 @@ namespace TestShaders
         [ComputeShader(1, 1, 1)]
         public void CS()
         {
-            StructuredInOut[DispatchThreadID.X] = StructuredInput[DispatchThreadID.Y];
+            Matrix4x4 m = StructuredInput[DispatchThreadID.Y];
+            StructuredInOut[DispatchThreadID.X].X = m.M11;
             StructuredInOut[DispatchThreadID.Y].Z = 1;
 
             RWBufferWithCustomStruct[0].Color = new Vector3(1, 2, 3);

--- a/src/ShaderGen/Metal/MetalBackend.cs
+++ b/src/ShaderGen/Metal/MetalBackend.cs
@@ -191,7 +191,7 @@ namespace ShaderGen.Metal
 
         private string WriteStructuredBuffer(ResourceDefinition rd, int binding)
         {
-            return $"constant {CSharpToShaderType(rd.ValueType.Name)} &{rd.Name} [[ buffer({binding}) ]]";
+            return $"constant {CSharpToShaderType(rd.ValueType.Name)} *{rd.Name} [[ buffer({binding}) ]]";
         }
 
         private string WriteRWStructuredBuffer(ResourceDefinition rd, int binding)
@@ -382,8 +382,9 @@ namespace ShaderGen.Metal
                 case ShaderResourceKind.Sampler:
                     return $"thread sampler {rd.Name};";
                 case ShaderResourceKind.Uniform:
-                case ShaderResourceKind.StructuredBuffer:
                     return $"constant {CSharpToShaderType(rd.ValueType.Name)}& {rd.Name};";
+                case ShaderResourceKind.StructuredBuffer:
+                    return $"constant {CSharpToShaderType(rd.ValueType.Name)}* {rd.Name};";
                 case ShaderResourceKind.RWStructuredBuffer:
                     return $"device {CSharpToShaderType(rd.ValueType.Name)}* {rd.Name};";
                 default:
@@ -407,8 +408,9 @@ namespace ShaderGen.Metal
                 case ShaderResourceKind.Sampler:
                     return $"thread sampler {rd.Name}_param";
                 case ShaderResourceKind.Uniform:
-                case ShaderResourceKind.StructuredBuffer:
                     return $"constant {CSharpToShaderType(rd.ValueType.Name)}& {rd.Name}_param";
+                case ShaderResourceKind.StructuredBuffer:
+                    return $"constant {CSharpToShaderType(rd.ValueType.Name)}* {rd.Name}_param";
                 case ShaderResourceKind.RWStructuredBuffer:
                     return $"device {CSharpToShaderType(rd.ValueType.Name)}* {rd.Name}_param";
                 default:


### PR DESCRIPTION
Previously, the Metal backend was treating structured buffers the same as uniform buffers - containers of a single element, rather than pointers to an array. The `SimpleCompute` test happened to pass because of Metal's implicit conversion from `float` to `float4`.