### PR TITLE
Fix break statements inside blocks inside switch cases

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/SwitchStatements.cs
+++ b/src/ShaderGen.Tests/TestAssets/SwitchStatements.cs
@@ -18,8 +18,10 @@ namespace TestShaders
                     break;
 
                 case 1:
+                {
                     x = 3;
                     break;
+                }
 
                 default:
                     x = 0;

--- a/src/ShaderGen/ShaderMethodVisitor.cs
+++ b/src/ShaderGen/ShaderMethodVisitor.cs
@@ -450,12 +450,10 @@ namespace ShaderGen
                 {
                     sb.AppendLine(Visit(statement));
                 }
-                sb.AppendLine("break;");
             }
             sb.AppendLine("}");
             return sb.ToString();
         }
-
         public override string VisitCaseSwitchLabel(CaseSwitchLabelSyntax node)
         {
             StringBuilder sb = new StringBuilder();
@@ -468,6 +466,11 @@ namespace ShaderGen
             StringBuilder sb = new StringBuilder();
             sb.AppendLine("default:");
             return sb.ToString();
+        }
+
+        public override string VisitBreakStatement(BreakStatementSyntax node)
+        {
+            return "break;";
         }
 
         public override string VisitPrefixUnaryExpression(PrefixUnaryExpressionSyntax node)


### PR DESCRIPTION
This fixes a mistake I made when I first implemented `switch` statements. I thought `break;` was something special in a `SwitchSectionSyntax`, but it's just a normal statement, which can exist in multiple types of parent node.