### PR TITLE
Don't offset vertex buffers in Metal backend

### DIFF
--- a/src/ShaderGen/Metal/MetalBackend.cs
+++ b/src/ShaderGen/Metal/MetalBackend.cs
@@ -77,12 +77,6 @@ namespace ShaderGen.Metal
 
             List<string> resourceArgList = new List<string>();
             int bufferBinding = 0;
-            if (function.Type == ShaderFunctionType.VertexEntryPoint
-                && function.Parameters.Length > 0)
-            {
-                bufferBinding = 1;
-            }
-
             int textureBinding = 0;
             int samplerBinding = 0;
             int setIndex = 0;


### PR DESCRIPTION
Fixes #35.

This requires a matching change on the application side, to bind vertex data buffers to slot(s) *after* any other vertex-stage uniform or structured buffers.

I'll prepare a PR to Veldrid with that change.