### PR TITLE
Check for resources not referenced in entry function

### DIFF
--- a/src/ShaderGen/Glsl/GlslBackendBase.cs
+++ b/src/ShaderGen/Glsl/GlslBackendBase.cs
@@ -94,6 +94,7 @@ namespace ShaderGen.Glsl
                         break;
                     case ShaderResourceKind.Texture2DMS:
                         WriteTexture2DMS(sb, rd);
+                        function.UsesTexture2DMS = true;
                         break;
                     case ShaderResourceKind.Sampler:
                         WriteSampler(sb, rd);
@@ -101,6 +102,7 @@ namespace ShaderGen.Glsl
                     case ShaderResourceKind.StructuredBuffer:
                     case ShaderResourceKind.RWStructuredBuffer:
                         WriteStructuredBuffer(sb, rd, rd.ResourceKind == ShaderResourceKind.StructuredBuffer);
+                        function.UsesStructuredBuffer = true;
                         break;
                     case ShaderResourceKind.RWTexture2D:
                         WriteRWTexture2D(sb, rd);


### PR DESCRIPTION
This fixes a bug that occured when structured buffers/texture 2ds were used outside the entry function. The glsl version wasn't increased correctly causing compile errors