### PR TITLE
Implement comparison sampling

### DIFF
--- a/src/ShaderGen.Primitives/SamplerComparisonResource.cs
+++ b/src/ShaderGen.Primitives/SamplerComparisonResource.cs
@@ -1,0 +1,6 @@
+﻿namespace ShaderGen
+{
+    public class SamplerComparisonResource
+    {
+    }
+}

--- a/src/ShaderGen.Primitives/ShaderBuiltins.cs
+++ b/src/ShaderGen.Primitives/ShaderBuiltins.cs
@@ -29,6 +29,10 @@ namespace ShaderGen
             uint sampleIndex) => throw new ShaderBuiltinException();
         public static T Load<T>(RWTexture2DResource<T> texture, UInt2 texCoords) where T : struct => throw new ShaderBuiltinException();
         public static T Store<T>(RWTexture2DResource<T> texture, UInt2 texCoords, T value) where T : struct => throw new ShaderBuiltinException();
+        public static float SampleComparisonLevelZero(Texture2DResource texture, SamplerComparisonResource sampler, Vector2 texCoords, float compareValue)
+            => throw new ShaderBuiltinException();
+        public static float SampleComparisonLevelZero(Texture2DArrayResource texture, SamplerComparisonResource sampler, Vector2 texCoords, uint arrayLayer, float compareValue)
+            => throw new ShaderBuiltinException();
         public static void Discard() => throw new ShaderBuiltinException();
         public static Vector2 ClipToTextureCoordinates(Vector4 clipCoordinates) => throw new ShaderBuiltinException();
 

--- a/src/ShaderGen.Tests/ShaderGeneratorTests.cs
+++ b/src/ShaderGen.Tests/ShaderGeneratorTests.cs
@@ -47,6 +47,7 @@ namespace ShaderGen.Tests
             yield return new object[] { null, "TestShaders.ExpressionBodiedMethods.ExpressionBodyWithReturn" };
             yield return new object[] { null, "TestShaders.ExpressionBodiedMethods.ExpressionBodyWithoutReturn" };
             yield return new object[] { "TestShaders.StructuredBufferTestShader.VS", null };
+            yield return new object[] { null, "TestShaders.DepthTextureSamplerFragment.FS" };
         }
 
         public static IEnumerable<object[]> ComputeShaders()

--- a/src/ShaderGen.Tests/TestAssets/DepthTextureSamplerFragment.cs
+++ b/src/ShaderGen.Tests/TestAssets/DepthTextureSamplerFragment.cs
@@ -24,7 +24,20 @@ namespace TestShaders
             float arraySample = SampleComparisonLevelZero(TexArray, Sampler, new Vector2(1, 2), 3, 0.5f);
             return new Vector4(
                 SampleComparisonLevelZero(Tex2D, Sampler, input.TextureCoordinate, 0.5f),
-                0, 0, 1);
+                SampleMethod(Tex2D, Sampler), 
+                0, 
+                1);
+        }
+
+        private float SampleMethod(Texture2DResource depthTexture, SamplerComparisonResource mySampler)
+        {
+            return SampleComparisonLevelZero(depthTexture, mySampler, Vector2.Zero, 0.2f)
+                + SampleMethodInner(depthTexture, mySampler);
+        }
+
+        private float SampleMethodInner(Texture2DResource depthTexture2, SamplerComparisonResource mySampler)
+        {
+            return SampleComparisonLevelZero(depthTexture2, mySampler, Vector2.Zero, 0.2f);
         }
     }
 }

--- a/src/ShaderGen.Tests/TestAssets/DepthTextureSamplerFragment.cs
+++ b/src/ShaderGen.Tests/TestAssets/DepthTextureSamplerFragment.cs
@@ -1,0 +1,30 @@
+﻿using ShaderGen;
+using System.Numerics;
+using static ShaderGen.ShaderBuiltins;
+
+namespace TestShaders
+{
+    public class DepthTextureSamplerFragment
+    {
+        public struct FragmentInput
+        {
+            [VertexSemantic(SemanticType.SystemPosition)]
+            public Vector4 Position;
+            [VertexSemantic(SemanticType.TextureCoordinate)]
+            public Vector2 TextureCoordinate;
+        }
+
+        public Texture2DResource Tex2D;
+        public Texture2DArrayResource TexArray;
+        public SamplerComparisonResource Sampler;
+
+        [FragmentShader]
+        public Vector4 FS(FragmentInput input)
+        {
+            float arraySample = SampleComparisonLevelZero(TexArray, Sampler, new Vector2(1, 2), 3, 0.5f);
+            return new Vector4(
+                SampleComparisonLevelZero(Tex2D, Sampler, input.TextureCoordinate, 0.5f),
+                0, 0, 1);
+        }
+    }
+}

--- a/src/ShaderGen/Glsl/Glsl330Backend.cs
+++ b/src/ShaderGen/Glsl/Glsl330Backend.cs
@@ -24,6 +24,7 @@ namespace ShaderGen.Glsl
             sb.AppendLine($"#version {version}");
             sb.AppendLine();
             sb.AppendLine($"struct SamplerDummy {{ int _dummyValue; }};");
+            sb.AppendLine($"struct SamplerComparisonDummy {{ int _dummyValue; }};");
             sb.AppendLine();
         }
 
@@ -35,18 +36,33 @@ namespace ShaderGen.Glsl
 
         protected override void WriteSamplerComparison(StringBuilder sb, ResourceDefinition rd)
         {
-            throw new System.NotImplementedException();
+            sb.AppendLine($"const SamplerComparisonDummy {CorrectIdentifier(rd.Name)} = SamplerComparisonDummy(0);");
+            sb.AppendLine();
         }
 
         protected override void WriteTexture2D(StringBuilder sb, ResourceDefinition rd)
         {
-            sb.AppendLine($"uniform sampler2D {CorrectIdentifier(rd.Name)};");
+            if (rd.IsTextureUsedAsDepthTexture)
+            {
+                sb.AppendLine($"uniform sampler2DShadow {CorrectIdentifier(rd.Name)};");
+            }
+            else
+            {
+                sb.AppendLine($"uniform sampler2D {CorrectIdentifier(rd.Name)};");
+            }
             sb.AppendLine();
         }
 
         protected override void WriteTexture2DArray(StringBuilder sb, ResourceDefinition rd)
         {
-            sb.AppendLine($"uniform sampler2DArray {CorrectIdentifier(rd.Name)};");
+            if (rd.IsTextureUsedAsDepthTexture)
+            {
+                sb.AppendLine($"uniform sampler2DArrayShadow {CorrectIdentifier(rd.Name)};");
+            }
+            else
+            {
+                sb.AppendLine($"uniform sampler2DArray {CorrectIdentifier(rd.Name)};");
+            }
             sb.AppendLine();
         }
 
@@ -118,6 +134,11 @@ namespace ShaderGen.Glsl
         protected override void EmitGlPositionCorrection(StringBuilder sb)
         {
             sb.AppendLine($"        gl_Position.z = gl_Position.z * 2.0 - gl_Position.w;");
+        }
+
+        protected override ShaderMethodVisitor VisitShaderMethod(string setName, ShaderFunction func)
+        {
+            return new Glsl330MethodVisitor(Compilation, setName, func, this);
         }
     }
 }

--- a/src/ShaderGen/Glsl/Glsl330Backend.cs
+++ b/src/ShaderGen/Glsl/Glsl330Backend.cs
@@ -138,7 +138,7 @@ namespace ShaderGen.Glsl
 
         protected override ShaderMethodVisitor VisitShaderMethod(string setName, ShaderFunction func)
         {
-            return new Glsl330MethodVisitor(Compilation, setName, func, this);
+            return new GlslOpenGLMethodVisitor(Compilation, setName, func, this);
         }
     }
 }

--- a/src/ShaderGen/Glsl/Glsl330Backend.cs
+++ b/src/ShaderGen/Glsl/Glsl330Backend.cs
@@ -33,6 +33,11 @@ namespace ShaderGen.Glsl
             sb.AppendLine();
         }
 
+        protected override void WriteSamplerComparison(StringBuilder sb, ResourceDefinition rd)
+        {
+            throw new System.NotImplementedException();
+        }
+
         protected override void WriteTexture2D(StringBuilder sb, ResourceDefinition rd)
         {
             sb.AppendLine($"uniform sampler2D {CorrectIdentifier(rd.Name)};");

--- a/src/ShaderGen/Glsl/Glsl330KnownFunctions.cs
+++ b/src/ShaderGen/Glsl/Glsl330KnownFunctions.cs
@@ -31,6 +31,7 @@ namespace ShaderGen.Glsl
                 { "Mul", MatrixMul },
                 { "Sample", Sample },
                 { "SampleGrad", SampleGrad },
+                { "SampleComparisonLevelZero", SampleComparisonLevelZero },
                 { "Load", Load },
                 { "Store", Store },
                 { "Discard", Discard },
@@ -251,6 +252,18 @@ namespace ShaderGen.Glsl
             else
             {
                 return $"textureGrad({parameters[0].Identifier}, {parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier})";
+            }
+        }
+
+        private static string SampleComparisonLevelZero(string typeName, string methodName, InvocationParameterInfo[] parameters)
+        {
+            if (parameters[0].FullTypeName == "ShaderGen.Texture2DArrayResource")
+            {
+                return $"texture({parameters[0].Identifier}, vec4({parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier}))";
+            }
+            else
+            {
+                return $"texture({parameters[0].Identifier}, vec3({parameters[2].Identifier}, {parameters[3].Identifier}))";
             }
         }
 

--- a/src/ShaderGen/Glsl/Glsl330KnownFunctions.cs
+++ b/src/ShaderGen/Glsl/Glsl330KnownFunctions.cs
@@ -259,11 +259,11 @@ namespace ShaderGen.Glsl
         {
             if (parameters[0].FullTypeName == "ShaderGen.Texture2DArrayResource")
             {
-                return $"texture({parameters[0].Identifier}, vec4({parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier}))";
+                return $"textureGrad({parameters[0].Identifier}, vec4({parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier}), vec2(0.0), vec2(0.0))";
             }
             else
             {
-                return $"texture({parameters[0].Identifier}, vec3({parameters[2].Identifier}, {parameters[3].Identifier}))";
+                return $"textureLod({parameters[0].Identifier}, vec3({parameters[2].Identifier}, {parameters[3].Identifier}), 0.0)";
             }
         }
 

--- a/src/ShaderGen/Glsl/Glsl330MethodVisitor.cs
+++ b/src/ShaderGen/Glsl/Glsl330MethodVisitor.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace ShaderGen.Glsl
+{
+    internal class Glsl330MethodVisitor : ShaderMethodVisitor
+    {
+        public Glsl330MethodVisitor(Compilation compilation, string setName, ShaderFunction shaderFunction, LanguageBackend backend)
+            : base(compilation, setName, shaderFunction, backend)
+        {
+        }
+
+        protected override string FormatParameter(ParameterDefinition pd)
+        {
+            string parameterType;
+
+            if (_backend.GetContext(_setName).Resources.Any(x => x.IsTextureUsedAsDepthTexture && x.ParameterSymbols.Contains(pd.Symbol)))
+            {
+                switch (pd.Type.Name)
+                {
+                    case "ShaderGen.Texture2DResource":
+                        parameterType = "sampler2DShadow";
+                        break;
+
+                    case "ShaderGen.Texture2DArrayResource":
+                        parameterType = "sampler2DArrayShadow";
+                        break;
+
+                    default:
+                        throw new System.NotImplementedException();
+                }
+            }
+            else
+            {
+                parameterType = _backend.CSharpToShaderType(pd.Type.Name);
+            }
+
+            return $"{_backend.ParameterDirection(pd.Direction)} {parameterType} {_backend.CorrectIdentifier(pd.Name)}";
+        }
+    }
+}

--- a/src/ShaderGen/Glsl/Glsl450Backend.cs
+++ b/src/ShaderGen/Glsl/Glsl450Backend.cs
@@ -53,6 +53,15 @@ namespace ShaderGen.Glsl
             sb.AppendLine(";");
         }
 
+        protected override void WriteSamplerComparison(StringBuilder sb, ResourceDefinition rd)
+        {
+            sb.Append(FormatLayoutStr(rd));
+            sb.Append(' ');
+            sb.Append("uniform samplerShadow ");
+            sb.Append(CorrectIdentifier(rd.Name));
+            sb.AppendLine(";");
+        }
+
         protected override void WriteTexture2D(StringBuilder sb, ResourceDefinition rd)
         {
             sb.Append(FormatLayoutStr(rd));

--- a/src/ShaderGen/Glsl/Glsl450KnownFunctions.cs
+++ b/src/ShaderGen/Glsl/Glsl450KnownFunctions.cs
@@ -272,11 +272,12 @@ namespace ShaderGen.Glsl
         {
             if (parameters[0].FullTypeName == "ShaderGen.Texture2DResource")
             {
-                return $"texture(sampler2DShadow({parameters[0].Identifier}, {parameters[1].Identifier}), vec3({parameters[2].Identifier}, {parameters[3].Identifier}))";
+                return $"textureLod(sampler2DShadow({parameters[0].Identifier}, {parameters[1].Identifier}), vec3({parameters[2].Identifier}, {parameters[3].Identifier}), 0.0)";
             }
             else if (parameters[0].FullTypeName == "ShaderGen.Texture2DArrayResource")
             {
-                return $"texture(sampler2DArrayShadow({parameters[0].Identifier}, {parameters[1].Identifier}), vec4({parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier}))";
+                // See https://github.com/KhronosGroup/SPIRV-Cross/issues/207 for why we need to use textureGrad here instead of textureLod.
+                return $"textureGrad(sampler2DArrayShadow({parameters[0].Identifier}, {parameters[1].Identifier}), vec4({parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier}), vec2(0.0), vec2(0.0))";
             }
             else
             {

--- a/src/ShaderGen/Glsl/Glsl450KnownFunctions.cs
+++ b/src/ShaderGen/Glsl/Glsl450KnownFunctions.cs
@@ -32,6 +32,7 @@ namespace ShaderGen.Glsl
                 { "Mul", MatrixMul },
                 { "Sample", Sample },
                 { "SampleGrad", SampleGrad },
+                { "SampleComparisonLevelZero", SampleComparisonLevelZero },
                 { "Load", Load },
                 { "Store", Store },
                 { "Discard", Discard },
@@ -260,6 +261,22 @@ namespace ShaderGen.Glsl
             else if (parameters[0].FullTypeName == "ShaderGen.Texture2DArrayResource")
             {
                 return $"textureGrad(sampler2DArray({parameters[0].Identifier}, {parameters[1].Identifier}), vec3({parameters[2].Identifier}, {parameters[3].Identifier}), {parameters[4].Identifier}, {parameters[5].Identifier})";
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        private static string SampleComparisonLevelZero(string typeName, string methodName, InvocationParameterInfo[] parameters)
+        {
+            if (parameters[0].FullTypeName == "ShaderGen.Texture2DResource")
+            {
+                return $"texture(sampler2DShadow({parameters[0].Identifier}, {parameters[1].Identifier}), vec3({parameters[2].Identifier}, {parameters[3].Identifier}))";
+            }
+            else if (parameters[0].FullTypeName == "ShaderGen.Texture2DArrayResource")
+            {
+                return $"texture(sampler2DArrayShadow({parameters[0].Identifier}, {parameters[1].Identifier}), vec4({parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier}))";
             }
             else
             {

--- a/src/ShaderGen/Glsl/GlslBackendBase.cs
+++ b/src/ShaderGen/Glsl/GlslBackendBase.cs
@@ -99,6 +99,9 @@ namespace ShaderGen.Glsl
                     case ShaderResourceKind.Sampler:
                         WriteSampler(sb, rd);
                         break;
+                    case ShaderResourceKind.SamplerComparison:
+                        WriteSamplerComparison(sb, rd);
+                        break;
                     case ShaderResourceKind.StructuredBuffer:
                     case ShaderResourceKind.RWStructuredBuffer:
                         WriteStructuredBuffer(sb, rd, rd.ResourceKind == ShaderResourceKind.StructuredBuffer);
@@ -380,6 +383,7 @@ namespace ShaderGen.Glsl
         protected abstract void WriteVersionHeader(ShaderFunction function, StringBuilder sb);
         protected abstract void WriteUniform(StringBuilder sb, ResourceDefinition rd);
         protected abstract void WriteSampler(StringBuilder sb, ResourceDefinition rd);
+        protected abstract void WriteSamplerComparison(StringBuilder sb, ResourceDefinition rd);
         protected abstract void WriteTexture2D(StringBuilder sb, ResourceDefinition rd);
         protected abstract void WriteTexture2DArray(StringBuilder sb, ResourceDefinition rd);
         protected abstract void WriteTextureCube(StringBuilder sb, ResourceDefinition rd);

--- a/src/ShaderGen/Glsl/GlslEs300Backend.cs
+++ b/src/ShaderGen/Glsl/GlslEs300Backend.cs
@@ -28,7 +28,9 @@ namespace ShaderGen.Glsl
             sb.AppendLine($"precision mediump float;");
             sb.AppendLine($"precision mediump int;");
             sb.AppendLine($"precision mediump sampler2D;");
+            sb.AppendLine($"precision mediump sampler2DShadow;");
             sb.AppendLine($"precision mediump sampler2DArray;");
+            sb.AppendLine($"precision mediump sampler2DArrayShadow;");
             if (useVersion320)
             {
                 sb.AppendLine($"precision mediump sampler2DMS;");
@@ -36,6 +38,7 @@ namespace ShaderGen.Glsl
             sb.AppendLine();
 
             sb.AppendLine($"struct SamplerDummy {{ int _dummyValue; }};");
+            sb.AppendLine($"struct SamplerComparisonDummy {{ int _dummyValue; }};");
             sb.AppendLine();
         }
 
@@ -47,18 +50,33 @@ namespace ShaderGen.Glsl
 
         protected override void WriteSamplerComparison(StringBuilder sb, ResourceDefinition rd)
         {
-            throw new System.NotImplementedException();
+            sb.AppendLine($"const SamplerComparisonDummy {CorrectIdentifier(rd.Name)} = SamplerComparisonDummy(0);");
+            sb.AppendLine();
         }
 
         protected override void WriteTexture2D(StringBuilder sb, ResourceDefinition rd)
         {
-            sb.AppendLine($"uniform sampler2D {CorrectIdentifier(rd.Name)};");
+            if (rd.IsTextureUsedAsDepthTexture)
+            {
+                sb.AppendLine($"uniform sampler2DShadow {CorrectIdentifier(rd.Name)};");
+            }
+            else
+            {
+                sb.AppendLine($"uniform sampler2D {CorrectIdentifier(rd.Name)};");
+            }
             sb.AppendLine();
         }
 
         protected override void WriteTexture2DArray(StringBuilder sb, ResourceDefinition rd)
         {
-            sb.AppendLine($"uniform sampler2DArray {CorrectIdentifier(rd.Name)};");
+            if (rd.IsTextureUsedAsDepthTexture)
+            {
+                sb.AppendLine($"uniform sampler2DArrayShadow {CorrectIdentifier(rd.Name)};");
+            }
+            else
+            {
+                sb.AppendLine($"uniform sampler2DArray {CorrectIdentifier(rd.Name)};");
+            }
             sb.AppendLine();
         }
 
@@ -177,6 +195,11 @@ namespace ShaderGen.Glsl
         protected override void EmitGlPositionCorrection(StringBuilder sb)
         {
             sb.AppendLine($"        gl_Position.z = gl_Position.z * 2.0 - gl_Position.w;");
+        }
+
+        protected override ShaderMethodVisitor VisitShaderMethod(string setName, ShaderFunction func)
+        {
+            return new GlslOpenGLMethodVisitor(Compilation, setName, func, this);
         }
     }
 }

--- a/src/ShaderGen/Glsl/GlslEs300Backend.cs
+++ b/src/ShaderGen/Glsl/GlslEs300Backend.cs
@@ -45,6 +45,11 @@ namespace ShaderGen.Glsl
             sb.AppendLine();
         }
 
+        protected override void WriteSamplerComparison(StringBuilder sb, ResourceDefinition rd)
+        {
+            throw new System.NotImplementedException();
+        }
+
         protected override void WriteTexture2D(StringBuilder sb, ResourceDefinition rd)
         {
             sb.AppendLine($"uniform sampler2D {CorrectIdentifier(rd.Name)};");

--- a/src/ShaderGen/Glsl/GlslEs300KnownFunctions.cs
+++ b/src/ShaderGen/Glsl/GlslEs300KnownFunctions.cs
@@ -271,11 +271,11 @@ namespace ShaderGen.Glsl
         {
             if (parameters[0].FullTypeName == "ShaderGen.Texture2DArrayResource")
             {
-                return $"texture({parameters[0].Identifier}, vec4({parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier}))";
+                return $"textureGrad({parameters[0].Identifier}, vec4({parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier}), vec2(0.0), vec2(0.0))";
             }
             else
             {
-                return $"texture({parameters[0].Identifier}, vec3({parameters[2].Identifier}, {parameters[3].Identifier}))";
+                return $"textureLod({parameters[0].Identifier}, vec3({parameters[2].Identifier}, {parameters[3].Identifier}), 0.0)";
             }
         }
 

--- a/src/ShaderGen/Glsl/GlslEs300KnownFunctions.cs
+++ b/src/ShaderGen/Glsl/GlslEs300KnownFunctions.cs
@@ -31,6 +31,7 @@ namespace ShaderGen.Glsl
                 { "Mul", MatrixMul },
                 { "Sample", Sample },
                 { "SampleGrad", SampleGrad },
+                { "SampleComparisonLevelZero", SampleComparisonLevelZero },
                 { "Load", Load },
                 { "Discard", Discard },
                 { "Saturate", Saturate },
@@ -263,6 +264,18 @@ namespace ShaderGen.Glsl
             else
             {
                 return $"textureGrad({parameters[0].Identifier}, {parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier})";
+            }
+        }
+
+        private static string SampleComparisonLevelZero(string typeName, string methodName, InvocationParameterInfo[] parameters)
+        {
+            if (parameters[0].FullTypeName == "ShaderGen.Texture2DArrayResource")
+            {
+                return $"texture({parameters[0].Identifier}, vec4({parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier}))";
+            }
+            else
+            {
+                return $"texture({parameters[0].Identifier}, vec3({parameters[2].Identifier}, {parameters[3].Identifier}))";
             }
         }
 

--- a/src/ShaderGen/Glsl/GlslKnownTypes.cs
+++ b/src/ShaderGen/Glsl/GlslKnownTypes.cs
@@ -30,6 +30,7 @@ namespace ShaderGen.Glsl
             { "ShaderGen.Texture2DArrayResource", "sampler2DArray" },
             { "ShaderGen.TextureCubeResource", "samplerCube" },
             { "ShaderGen.SamplerResource", "SamplerDummy" },
+            { "ShaderGen.SamplerComparisonResource", "SamplerComparisonDummy" },
         };
 
         private static readonly Dictionary<string, string> s_knownTypesVulkan = new Dictionary<string, string>()

--- a/src/ShaderGen/Glsl/GlslKnownTypes.cs
+++ b/src/ShaderGen/Glsl/GlslKnownTypes.cs
@@ -38,6 +38,7 @@ namespace ShaderGen.Glsl
             { "ShaderGen.Texture2DArrayResource", "texture2DArray" },
             { "ShaderGen.TextureCubeResource", "textureCube" },
             { "ShaderGen.SamplerResource", "sampler" },
+            { "ShaderGen.SamplerComparisonResource", "samplerShadow" },
         };
 
 

--- a/src/ShaderGen/Glsl/GlslOpenGLMethodVisitor.cs
+++ b/src/ShaderGen/Glsl/GlslOpenGLMethodVisitor.cs
@@ -3,9 +3,9 @@ using Microsoft.CodeAnalysis;
 
 namespace ShaderGen.Glsl
 {
-    internal class Glsl330MethodVisitor : ShaderMethodVisitor
+    internal class GlslOpenGLMethodVisitor : ShaderMethodVisitor
     {
-        public Glsl330MethodVisitor(Compilation compilation, string setName, ShaderFunction shaderFunction, LanguageBackend backend)
+        public GlslOpenGLMethodVisitor(Compilation compilation, string setName, ShaderFunction shaderFunction, LanguageBackend backend)
             : base(compilation, setName, shaderFunction, backend)
         {
         }

--- a/src/ShaderGen/Glsl/GlslOpenGLMethodVisitor.cs
+++ b/src/ShaderGen/Glsl/GlslOpenGLMethodVisitor.cs
@@ -27,7 +27,7 @@ namespace ShaderGen.Glsl
                         break;
 
                     default:
-                        throw new System.NotImplementedException();
+                        throw new ShaderGenerationException($"Unexpected texture parameter type: {pd.Type.Name}.");
                 }
             }
             else

--- a/src/ShaderGen/Hlsl/HlslBackend.cs
+++ b/src/ShaderGen/Hlsl/HlslBackend.cs
@@ -96,6 +96,12 @@ namespace ShaderGen.Hlsl
             sb.AppendLine();
         }
 
+        private void WriteSamplerComparison(StringBuilder sb, ResourceDefinition rd, int binding)
+        {
+            sb.AppendLine($"SamplerComparisonState {CorrectIdentifier(rd.Name)} : register(s{binding});");
+            sb.AppendLine();
+        }
+
         private void WriteTexture2D(StringBuilder sb, ResourceDefinition rd, int binding)
         {
             sb.AppendLine($"Texture2D {CorrectIdentifier(rd.Name)} : register(t{binding});");
@@ -212,6 +218,10 @@ namespace ShaderGen.Hlsl
                             break;
                         case ShaderResourceKind.Sampler:
                             WriteSampler(sb, rd, samplerBinding);
+                            samplerBinding++;
+                            break;
+                        case ShaderResourceKind.SamplerComparison:
+                            WriteSamplerComparison(sb, rd, samplerBinding);
                             samplerBinding++;
                             break;
                         case ShaderResourceKind.StructuredBuffer:

--- a/src/ShaderGen/Hlsl/HlslKnownFunctions.cs
+++ b/src/ShaderGen/Hlsl/HlslKnownFunctions.cs
@@ -31,6 +31,7 @@ namespace ShaderGen.Hlsl
                 { "Mod", SimpleNameTranslator("fmod") },
                 { "Sample", Sample },
                 { "SampleGrad", SampleGrad },
+                { "SampleComparisonLevelZero", SampleComparisonLevelZero },
                 { "Load", Load },
                 { "Store", Store },
                 { "Discard", Discard },
@@ -245,6 +246,18 @@ namespace ShaderGen.Hlsl
             else
             {
                 return $"{parameters[0].Identifier}.SampleGrad({parameters[1].Identifier}, {parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier})";
+            }
+        }
+
+        private static string SampleComparisonLevelZero(string typeName, string methodName, InvocationParameterInfo[] parameters)
+        {
+            if (parameters[0].FullTypeName == "ShaderGen.Texture2DArrayResource")
+            {
+                return $"{parameters[0].Identifier}.SampleCmpLevelZero({parameters[1].Identifier}, float3({parameters[2].Identifier}, {parameters[3].Identifier}), {parameters[4].Identifier})";
+            }
+            else
+            {
+                return $"{parameters[0].Identifier}.SampleCmpLevelZero({parameters[1].Identifier}, {parameters[2].Identifier}, {parameters[3].Identifier})";
             }
         }
 

--- a/src/ShaderGen/Hlsl/HlslKnownTypes.cs
+++ b/src/ShaderGen/Hlsl/HlslKnownTypes.cs
@@ -15,6 +15,7 @@ namespace ShaderGen.Hlsl
             { "System.Numerics.Matrix4x4", "float4x4" },
             { "System.Void", "void" },
             { "ShaderGen.SamplerResource", "SamplerState" },
+            { "ShaderGen.SamplerComparisonResource", "SamplerComparisonState" },
             { "ShaderGen.Texture2DResource", "Texture2D" },
             { "ShaderGen.Texture2DArrayResource", "Texture2DArray" },
             { "ShaderGen.TextureCubeResource", "TextureCube" },

--- a/src/ShaderGen/Metal/MetalBackend.cs
+++ b/src/ShaderGen/Metal/MetalBackend.cs
@@ -125,6 +125,7 @@ namespace ShaderGen.Metal
                             textureBinding++;
                             break;
                         case ShaderResourceKind.Sampler:
+                        case ShaderResourceKind.SamplerComparison:
                             if (resourcesUsed.Contains(rd))
                             {
                                 resourceArgList.Add(WriteSampler(rd, samplerBinding));
@@ -367,6 +368,7 @@ namespace ShaderGen.Metal
                 case ShaderResourceKind.TextureCube:
                     return $"thread texturecube<float> {rd.Name};";
                 case ShaderResourceKind.Sampler:
+                case ShaderResourceKind.SamplerComparison:
                     return $"thread sampler {rd.Name};";
                 case ShaderResourceKind.Uniform:
                     return $"constant {CSharpToShaderType(rd.ValueType.Name)}& {rd.Name};";
@@ -395,6 +397,7 @@ namespace ShaderGen.Metal
                 case ShaderResourceKind.TextureCube:
                     return $"thread texturecube<float> {rd.Name}_param";
                 case ShaderResourceKind.Sampler:
+                case ShaderResourceKind.SamplerComparison:
                     return $"thread sampler {rd.Name}_param";
                 case ShaderResourceKind.Uniform:
                     return $"constant {CSharpToShaderType(rd.ValueType.Name)}& {rd.Name}_param";

--- a/src/ShaderGen/Metal/MetalKnownFunctions.cs
+++ b/src/ShaderGen/Metal/MetalKnownFunctions.cs
@@ -32,6 +32,7 @@ namespace ShaderGen.Metal
                 { "Mod", SimpleNameTranslator("fmod") },
                 { "Sample", Sample },
                 { "SampleGrad", SampleGrad },
+                { "SampleComparisonLevelZero", SampleComparisonLevelZero },
                 { "Load", Load },
                 { "Store", Store },
                 { "Discard", Discard },
@@ -277,6 +278,20 @@ namespace ShaderGen.Metal
             else
             {
                 return $"{parameters[0].Identifier}.sample({parameters[1].Identifier}, {parameters[2].Identifier}, gradient2d({parameters[3].Identifier}, {parameters[4].Identifier}))";
+            }
+        }
+
+        private static string SampleComparisonLevelZero(string typeName, string methodName, InvocationParameterInfo[] parameters)
+        {
+            if (parameters[0].FullTypeName == "ShaderGen.Texture2DArrayResource")
+            {
+                // Metal texture array sample_compare function:
+                // sample_compare(sampler s, float2 coord, uint array, float compare_value)
+                return $"{parameters[0].Identifier}.sample_compare({parameters[1].Identifier}, {parameters[2].Identifier}, {parameters[3].Identifier}, {parameters[4].Identifier})";
+            }
+            else
+            {
+                return $"{parameters[0].Identifier}.sample_compare({parameters[1].Identifier}, {parameters[2].Identifier}, {parameters[3].Identifier})";
             }
         }
 

--- a/src/ShaderGen/Metal/MetalKnownTypes.cs
+++ b/src/ShaderGen/Metal/MetalKnownTypes.cs
@@ -18,6 +18,7 @@ namespace ShaderGen.Metal
             { "ShaderGen.Texture2DArrayResource", "texture2d_array<float>" },
             { "ShaderGen.TextureCubeResource", "texturecube<float>" },
             { "ShaderGen.SamplerResource", "sampler" },
+            { "ShaderGen.SamplerComparisonResource", "sampler" },
             { "System.Boolean", "bool" },
             { "ShaderGen.UInt2", "uint2" },
             { "ShaderGen.UInt3", "uint3" },

--- a/src/ShaderGen/ParameterDefinition.cs
+++ b/src/ShaderGen/ParameterDefinition.cs
@@ -8,12 +8,14 @@ namespace ShaderGen
         public string Name { get; }
         public TypeReference Type { get; }
         public ParameterDirection Direction { get; }
+        public IParameterSymbol Symbol { get; }
 
-        public ParameterDefinition(string name, TypeReference type, ParameterDirection direction)
+        public ParameterDefinition(string name, TypeReference type, ParameterDirection direction, IParameterSymbol symbol)
         {
             Name = name;
             Type = type;
             Direction = direction;
+            Symbol = symbol;
         }
 
         public static ParameterDefinition GetParameterDefinition(Compilation compilation, ParameterSyntax ps)
@@ -36,7 +38,7 @@ namespace ShaderGen
                 direction = ParameterDirection.InOut;
             }
 
-            return new ParameterDefinition(name, new TypeReference(fullType), direction);
+            return new ParameterDefinition(name, new TypeReference(fullType), direction, declaredSymbol);
         }
     }
 

--- a/src/ShaderGen/ResourceDefinition.cs
+++ b/src/ShaderGen/ResourceDefinition.cs
@@ -1,4 +1,7 @@
-﻿namespace ShaderGen
+﻿using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+
+namespace ShaderGen
 {
     public class ResourceDefinition
     {
@@ -7,6 +10,18 @@
         public int Binding { get; }
         public TypeReference ValueType { get; }
         public ShaderResourceKind ResourceKind { get; }
+
+        /// <summary>
+        /// True if this resource is a texture type is passed to a comparison-sampling function.
+        /// Needed by the "legacy" GLSL backends.
+        /// </summary>
+        public bool IsTextureUsedAsDepthTexture { get; internal set; }
+
+        /// <summary>
+        /// If this is a texture, stores all the parameters that this texture is passed as an argument to.
+        /// Needed by the "legacy" GLSL backends.
+        /// </summary>
+        public List<IParameterSymbol> ParameterSymbols { get; } = new List<IParameterSymbol>();
 
         public ResourceDefinition(string name, int set, int binding, TypeReference valueType, ShaderResourceKind kind)
         {

--- a/src/ShaderGen/ShaderMethodVisitor.cs
+++ b/src/ShaderGen/ShaderMethodVisitor.cs
@@ -314,7 +314,7 @@ namespace ShaderGen
                     break;
 
                 default:
-                    throw new NotImplementedException();
+                    throw new ShaderGenerationException($"Unexpected symbol kind for texture object expression: {textureSymbol.Kind}.");
             }
         }
 

--- a/src/ShaderGen/ShaderResourceKind.cs
+++ b/src/ShaderGen/ShaderResourceKind.cs
@@ -11,5 +11,6 @@
         StructuredBuffer,
         RWStructuredBuffer,
         RWTexture2D,
+        SamplerComparison,
     }
 }

--- a/src/ShaderGen/ShaderSyntaxWalker.cs
+++ b/src/ShaderGen/ShaderSyntaxWalker.cs
@@ -267,7 +267,8 @@ namespace ShaderGen
                 && name != nameof(ShaderGen) + "." + nameof(Texture2DArrayResource)
                 && name != nameof(ShaderGen) + "." + nameof(TextureCubeResource)
                 && name != nameof(ShaderGen) + "." + nameof(Texture2DMSResource)
-                && name != nameof(ShaderGen) + "." + nameof(SamplerResource))
+                && name != nameof(ShaderGen) + "." + nameof(SamplerResource)
+                && name != nameof(ShaderGen) + "." + nameof(SamplerComparisonResource))
             {
                 if (typeInfo.Type.IsReferenceType)
                 {
@@ -297,6 +298,10 @@ namespace ShaderGen
             else if (fullTypeName == "ShaderGen.SamplerResource")
             {
                 return ShaderResourceKind.Sampler;
+            }
+            else if (fullTypeName == "ShaderGen.SamplerComparisonResource")
+            {
+                return ShaderResourceKind.SamplerComparison;
             }
             else if (fullTypeName.Contains("ShaderGen.RWStructuredBuffer"))
             {


### PR DESCRIPTION
This implements (in HLSL terminology) `SamplerComparisonState` and `SampleCmpLevelZero`.

So far, I've added:
* a `SamplerComparisonResource` class
* a `SampleComparisonLevelZero` builtin function

and implemented them for these backends:
* HLSL
* Metal
* GLSL 450

GLSL 330 and GLSL ES 300 are going to be problematic, because of the awkward relationship between samplers and textures. It looks like we need to know that a given texture is used for comparison sampling, in which case we should write it out as (for example) a `sampler2DShadow` instead of `sampler2D`. I need to think more about this.