### PR TITLE
Implement inline out variables

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/OutParameters.cs
+++ b/src/ShaderGen.Tests/TestAssets/OutParameters.cs
@@ -18,6 +18,9 @@ namespace TestShaders
             Vector2 zw;
             MyFunc(input.Position, ref xy, out zw);
 
+            MyFunc(input.Position, ref xy, out var zw2);
+            zw += zw2;
+
             SystemPosition4 output;
             output.Position.X = xy.X;
             output.Position.Y = xy.Y;


### PR DESCRIPTION
A nice-to-have that lets us use the "inline out variables" C#7 feature:

```
MyFunc(input.Position, out var xy);
```