### PR TITLE
Allow const variable declaration and usage

### DIFF
--- a/src/ShaderGen.Tests/ShaderModelTests.cs
+++ b/src/ShaderGen.Tests/ShaderModelTests.cs
@@ -97,7 +97,7 @@ namespace ShaderGen.Tests
             ShaderModel shaderModel = set.Model;
 
             Assert.Single(shaderModel.AllResources);
-            Assert.Equal(144, shaderModel.GetTypeSize(shaderModel.AllResources[0].ValueType));
+            Assert.Equal(208, shaderModel.GetTypeSize(shaderModel.AllResources[0].ValueType));
         }
 
         [Fact]

--- a/src/ShaderGen.Tests/TestAssets/PointLightInfoStructs.cs
+++ b/src/ShaderGen.Tests/TestAssets/PointLightInfoStructs.cs
@@ -6,12 +6,19 @@ namespace TestShaders
     public class PointLightTestShaders
     {
         public PointLightsInfo PointLights;
+        public const int MyOtherConst = 20;
 
         [VertexShader] SystemPosition4 VS(Position4 input)
         {
+            const int MyConst = 10;
+
             SystemPosition4 output;
-            PointLightInfo a = PointLights.PointLights[0];
-            Vector4 position = new Vector4(a.Position.XYZ(), 10);
+            Vector4 color = Vector4.Zero;
+            for (int i = 0; i < PointLightsInfo.MaxLights; i++)
+            {
+                PointLightInfo a = PointLights.PointLights[i];
+                color += new Vector4(a.Color, MyConst);
+            }
             output.Position = input.Position;
             return output;
         }
@@ -27,8 +34,11 @@ namespace TestShaders
 
     public struct PointLightsInfo
     {
+        public const int MaxLights = 4;
+
         public int NumActiveLights;
         public Vector3 _padding;
-        [ArraySize(4)] public PointLightInfo[] PointLights;
+        [ArraySize(MaxLights)] public PointLightInfo[] PointLights;
+        [ArraySize(2)] public PointLightInfo[] PointLights2;
     }
 }

--- a/src/ShaderGen/ShaderMethodVisitor.cs
+++ b/src/ShaderGen/ShaderMethodVisitor.cs
@@ -161,6 +161,11 @@ namespace ShaderGen
 
         public override string VisitLocalDeclarationStatement(LocalDeclarationStatementSyntax node)
         {
+            if (node.Modifiers.Any(x => x.IsKind(SyntaxKind.ConstKeyword)))
+            {
+                return " "; // TODO: Can't return empty string here because of validation check in VisitBlock
+            }
+
             return Visit(node.Declaration);
         }
 
@@ -211,7 +216,7 @@ namespace ShaderGen
                 }
 
                 // Static member access
-                if (symbol.Kind == SymbolKind.Property)
+                if (symbol.Kind == SymbolKind.Property || symbol.Kind == SymbolKind.Field)
                 {
                     return Visit(node.Name);
                 }
@@ -414,6 +419,16 @@ namespace ShaderGen
             else if (symbol.Kind == SymbolKind.Property)
             {
                 return _backend.FormatInvocation(_setName, containingTypeName, symbol.Name, Array.Empty<InvocationParameterInfo>());
+            }
+            else if (symbol is IFieldSymbol fs && fs.HasConstantValue)
+            {
+                // TODO: Share code to format constant values.
+                return fs.ConstantValue.ToString();
+            }
+            else if (symbol is ILocalSymbol ls && ls.HasConstantValue)
+            {
+                // TODO: Share code to format constant values.
+                return ls.ConstantValue.ToString();
             }
 
             string mapped = _backend.CSharpToShaderIdentifierName(symbolInfo);


### PR DESCRIPTION
Useful for a few things - in my use-case, sharing a "number of lights" variable between array declaration, and array iteration in the shader function.