### PR TITLE
Implement C# 7 "discards"

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/OutParameters.cs
+++ b/src/ShaderGen.Tests/TestAssets/OutParameters.cs
@@ -21,6 +21,9 @@ namespace TestShaders
             MyFunc(input.Position, ref xy, out var zw2);
             zw += zw2;
 
+            MyFunc(input.Position, ref xy, out _);
+            MyFunc(input.Position, ref xy, out _);
+
             SystemPosition4 output;
             output.Position.X = xy.X;
             output.Position.Y = xy.Y;


### PR DESCRIPTION
Adds support for C# 7's [discards](https://docs.microsoft.com/en-us/dotnet/csharp/discards).

Because this syntax obviously isn't supported in any shading language, I've chosen to declare these as dummy variables at the start of any method in which they are used. One dummy variable is written out per unique type.

So this:

``` csharp
private void DoSomething(out Vector2 v)
{
    v = Vector2.Zero;
}

public void MyFunc()
{
    DoSomething(out _);
    DoSomething(out _);
}
```

is converted to (something like) this:

``` hlsl
void DoSomething(out float2 v)
{
    v = float2(0, 0);
}

void MyFunc()
{
    float2 _shadergen_discard_float2;
    DoSomething(_shadergen_discard_float2);
    DoSomething(_shadergen_discard_float2);
}
```

This won't be an often-used feature, but it can be handy for re-using helper methods where you don't need all the functionality of the helper method, and don't care about some of the results. Hopefully the backend shader compilers will get rid of the unused code!