### PR TITLE
Fix usage of const fields declared in current class

### DIFF
--- a/src/ShaderGen.Tests/TestAssets/PointLightInfoStructs.cs
+++ b/src/ShaderGen.Tests/TestAssets/PointLightInfoStructs.cs
@@ -12,6 +12,9 @@ namespace TestShaders
         {
             const int MyConst = 10;
 
+            for (int i = 0; i < MyConst; i++) { }
+            for (int i = 0; i < MyOtherConst; i++) { }
+
             SystemPosition4 output;
             Vector4 color = Vector4.Zero;
             for (int i = 0; i < PointLightsInfo.MaxLights; i++)

--- a/src/ShaderGen/ShaderMethodVisitor.cs
+++ b/src/ShaderGen/ShaderMethodVisitor.cs
@@ -467,7 +467,12 @@ namespace ShaderGen
             {
                 TryRecognizeBuiltInVariable(symbolInfo);
             }
-            if (symbol.Kind == SymbolKind.Field && containingTypeName == _containingTypeName)
+            if (symbol is IFieldSymbol fs && fs.HasConstantValue)
+            {
+                // TODO: Share code to format constant values.
+                return fs.ConstantValue.ToString();
+            }
+            else if (symbol.Kind == SymbolKind.Field && containingTypeName == _containingTypeName)
             {
                 string symbolName = symbol.Name;
                 ResourceDefinition referencedResource = _backend.GetContext(_setName).Resources.Single(rd => rd.Name == symbolName);
@@ -480,11 +485,6 @@ namespace ShaderGen
             else if (symbol.Kind == SymbolKind.Property)
             {
                 return _backend.FormatInvocation(_setName, containingTypeName, symbol.Name, Array.Empty<InvocationParameterInfo>());
-            }
-            else if (symbol is IFieldSymbol fs && fs.HasConstantValue)
-            {
-                // TODO: Share code to format constant values.
-                return fs.ConstantValue.ToString();
             }
             else if (symbol is ILocalSymbol ls && ls.HasConstantValue)
             {


### PR DESCRIPTION
Fixes a bug in #46, when referencing `const` fields from the current class.