### PR TITLE
Fix wrong float formatting on non english cultures

### DIFF
--- a/src/ShaderGen/ShaderMethodVisitor.cs
+++ b/src/ShaderGen/ShaderMethodVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace ShaderGen
 {
@@ -470,7 +471,7 @@ namespace ShaderGen
             if (symbol is IFieldSymbol fs && fs.HasConstantValue)
             {
                 // TODO: Share code to format constant values.
-                return fs.ConstantValue.ToString();
+                return string.Format(CultureInfo.InvariantCulture,"{0}", fs.ConstantValue);
             }
             else if (symbol.Kind == SymbolKind.Field && containingTypeName == _containingTypeName)
             {
@@ -489,7 +490,7 @@ namespace ShaderGen
             else if (symbol is ILocalSymbol ls && ls.HasConstantValue)
             {
                 // TODO: Share code to format constant values.
-                return ls.ConstantValue.ToString();
+                return string.Format(CultureInfo.InvariantCulture, "{0}", ls.ConstantValue);
             }
 
             string mapped = _backend.CSharpToShaderIdentifierName(symbolInfo);


### PR DESCRIPTION
The issue here was that floats use ',' as a seperator instead of '.' for some cultures. This resulted in wrong produced shader code which would not compile or behave wrong. Here is an example:
```csharp
const float twoPi = 2 * 3.1415926535f;
var angle = textureMapping.Speed * t * twoPi;
```

produced 
```c
float angle = textureMapping.Speed * t * 6,283185;
```

on my machine (german culture).