### PR TITLE
Remove const qulifier from sampler declaration

### DIFF
--- a/src/ShaderGen/Glsl/Glsl330Backend.cs
+++ b/src/ShaderGen/Glsl/Glsl330Backend.cs
@@ -30,13 +30,13 @@ namespace ShaderGen.Glsl
 
         protected override void WriteSampler(StringBuilder sb, ResourceDefinition rd)
         {
-            sb.AppendLine($"const SamplerDummy {CorrectIdentifier(rd.Name)} = SamplerDummy(0);");
+            sb.AppendLine($"SamplerDummy {CorrectIdentifier(rd.Name)} = SamplerDummy(0);");
             sb.AppendLine();
         }
 
         protected override void WriteSamplerComparison(StringBuilder sb, ResourceDefinition rd)
         {
-            sb.AppendLine($"const SamplerComparisonDummy {CorrectIdentifier(rd.Name)} = SamplerComparisonDummy(0);");
+            sb.AppendLine($"SamplerComparisonDummy {CorrectIdentifier(rd.Name)} = SamplerComparisonDummy(0);");
             sb.AppendLine();
         }
 

--- a/src/ShaderGen/Glsl/GlslEs300Backend.cs
+++ b/src/ShaderGen/Glsl/GlslEs300Backend.cs
@@ -44,13 +44,13 @@ namespace ShaderGen.Glsl
 
         protected override void WriteSampler(StringBuilder sb, ResourceDefinition rd)
         {
-            sb.AppendLine($"const SamplerDummy {CorrectIdentifier(rd.Name)} = SamplerDummy(0);");
+            sb.AppendLine($"SamplerDummy {CorrectIdentifier(rd.Name)} = SamplerDummy(0);");
             sb.AppendLine();
         }
 
         protected override void WriteSamplerComparison(StringBuilder sb, ResourceDefinition rd)
         {
-            sb.AppendLine($"const SamplerComparisonDummy {CorrectIdentifier(rd.Name)} = SamplerComparisonDummy(0);");
+            sb.AppendLine($"SamplerComparisonDummy {CorrectIdentifier(rd.Name)} = SamplerComparisonDummy(0);");
             sb.AppendLine();
         }
 


### PR DESCRIPTION
Required so the sampler can be passed as parameter to functions