### PR TITLE
Fixes #60 by adding quotes around parameters.

### DIFF
--- a/src/ShaderGen.App/Program.cs
+++ b/src/ShaderGen.App/Program.cs
@@ -305,7 +305,7 @@ namespace ShaderGen.App
                     : type == ShaderFunctionType.FragmentEntryPoint ? "ps_5_0"
                     : "cs_5_0";
                 string outputPath = shaderPath + ".bytes";
-                string args = $"/T {profile} /E {entryPoint} {shaderPath} /Fo {outputPath}";
+                string args = $"/T \"{profile}\" /E \"{entryPoint}\" \"{shaderPath}\" /Fo \"{outputPath}\"";
                 string fxcPath = FindFxcExe();
                 ProcessStartInfo psi = new ProcessStartInfo(fxcPath, args);
                 psi.RedirectStandardOutput = true;


### PR DESCRIPTION
I've tested this by dropping the newly compiled `Shader.App.dll` into the NuGet cache directly and the error no longer occurs (and HLSL compilation succeeds).  There was no automated testing for ShaderGen.App in the existing project so I've not added an automatic test for this fix.