### PR TITLE
Changed to use DXC instead of SharpDX for HLSL compilation

### DIFF
--- a/src/ShaderGen.App/Program.cs
+++ b/src/ShaderGen.App/Program.cs
@@ -366,12 +366,20 @@ namespace ShaderGen.App
 
             var optimize = debug ? "-Od -Zi" : "-O3";
 
-            var profile = type switch
+            //var profile = type switch
+            //{
+            //    ShaderFunctionType.VertexEntryPoint   => "vs_6_0",
+            //    ShaderFunctionType.FragmentEntryPoint => "ps_6_0",
+            //    _ => "cs_6_0",
+            //};
+            var profile = "";
+            switch (type)
             {
-                ShaderFunctionType.VertexEntryPoint   => "vs_6_0",
-                ShaderFunctionType.FragmentEntryPoint => "ps_6_0",
-                _ => "cs_6_0",
-            };
+                case ShaderFunctionType.VertexEntryPoint  : profile = "vs_6_0";break;
+                case ShaderFunctionType.FragmentEntryPoint: profile = "ps_6_0";break;
+                case ShaderFunctionType.ComputeEntryPoint : profile = "cs_6_0";break;
+                default: throw new NotSupportedException();
+            }
 
             var outputPath = shaderPath + ".dxil";
 

--- a/src/ShaderGen.App/ShaderGen.App.csproj
+++ b/src/ShaderGen.App/ShaderGen.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ShaderGen.App/ShaderGen.App.csproj
+++ b/src/ShaderGen.App/ShaderGen.App.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\ShaderGen\ShaderGen.csproj" />
-    <PackageReference Include="SharpDX.D3DCompiler" Version="4.2.0" />
     <PackageReference Include="System.CommandLine" Version="0.1.0-e170407-3" />
   </ItemGroup>
 


### PR DESCRIPTION
Changed to use DirectX Shader Compiler(DXC) instead of SharpDX for HLSL compilation.

SharpDX.D3DCompiler was for Windows only.
With the change to dxc, ShaderGen now works on Linux and MacOS.

https://github.com/microsoft/DirectXShaderCompiler

